### PR TITLE
Cachyos 11.0 staging/ pipewire

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1709,7 +1709,10 @@ dnl **** Check for PipeWire ****
 if test "x$with_pipewire" != "xno";
 then
     WINE_PACKAGE_FLAGS(PIPEWIRE,[libpipewire-0.3],,,,
-        [AC_CHECK_HEADERS([pipewire/pipewire.h],,[PIPEWIRE_LIBS=""])])
+        [AC_CHECK_HEADERS([pipewire/pipewire.h],,[PIPEWIRE_LIBS=""])
+         AS_IF([test -n "$PIPEWIRE_LIBS"],
+            [AC_CHECK_DECL([pw_stream_get_time_n],,[PIPEWIRE_LIBS=""],
+                [[#include <pipewire/pipewire.h>]])])])
 fi
 WINE_NOTICE_WITH(pipewire, [test -z "$PIPEWIRE_LIBS"],
         [libpipewire-0.3 ${notice_platform}development files not found, PipeWire won't be supported.],

--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,7 @@ AC_ARG_WITH(pcap,      AS_HELP_STRING([--without-pcap],[do not use the Packet Ca
             [if test "x$withval" = "xno"; then ac_cv_header_pcap_pcap_h=no; fi])
 AC_ARG_WITH(pcsclite,  AS_HELP_STRING([--without-pcsclite],[do not use PCSC lite]))
 AC_ARG_WITH(piper,     AS_HELP_STRING([--without-piper],[do not use the Piper TTS library]))
+AC_ARG_WITH(pipewire,  AS_HELP_STRING([--without-pipewire],[do not use PipeWire sound support]))
 AC_ARG_WITH(pthread,   AS_HELP_STRING([--without-pthread],[do not use the pthread library]))
 AC_ARG_WITH(pulse,     AS_HELP_STRING([--without-pulse],[do not use PulseAudio sound support]))
 AC_ARG_WITH(sane,      AS_HELP_STRING([--without-sane],[do not use SANE (scanner support)]))
@@ -1704,6 +1705,16 @@ WINE_NOTICE_WITH(pulse, [test -z "$PULSE_LIBS"],
         [libpulse ${notice_platform}development files not found or too old, Pulse won't be supported.],
         [enable_winepulse_drv])
 
+dnl **** Check for PipeWire ****
+if test "x$with_pipewire" != "xno";
+then
+    WINE_PACKAGE_FLAGS(PIPEWIRE,[libpipewire-0.3],,,,
+        [AC_CHECK_HEADERS([pipewire/pipewire.h],,[PIPEWIRE_LIBS=""])])
+fi
+WINE_NOTICE_WITH(pipewire, [test -z "$PIPEWIRE_LIBS"],
+        [libpipewire-0.3 ${notice_platform}development files not found, PipeWire won't be supported.],
+        [enable_winepipewire_drv])
+
 dnl **** Check for FFmpeg ****
 if test "x$with_ffmpeg" != "xno";
 then
@@ -1940,8 +1951,8 @@ WINE_NOTICE_WITH(netapi,[test "x$ac_cv_lib_soname_netapi" = "x"],
 
 
 dnl **** Check for any sound system ****
-if test "x$enable_winealsa_drv$enable_winecoreaudio_drv$enable_winepulse_drv$enable_wineoss_drv$enable_wineandroid_drv" = xnonononono -a \
-        "x$with_alsa$with_coreaudio$with_oss$with_pulse" != xnononono
+if test "x$enable_winealsa_drv$enable_winecoreaudio_drv$enable_winepulse_drv$enable_wineoss_drv$enable_wineandroid_drv$enable_winepipewire_drv" = xnononononono -a \
+        "x$with_alsa$with_coreaudio$with_oss$with_pulse$with_pipewire" != xnonononono
 then
     WINE_WARNING([No sound system was found. Windows applications will be silent.])
 fi
@@ -3441,6 +3452,7 @@ WINE_CONFIG_MAKEFILE(dlls/winehid.sys)
 WINE_CONFIG_MAKEFILE(dlls/winemac.drv)
 WINE_CONFIG_MAKEFILE(dlls/winemapi)
 WINE_CONFIG_MAKEFILE(dlls/wineoss.drv)
+WINE_CONFIG_MAKEFILE(dlls/winepipewire.drv)
 WINE_CONFIG_MAKEFILE(dlls/wineps.drv)
 WINE_CONFIG_MAKEFILE(dlls/wineps16.drv16)
 WINE_CONFIG_MAKEFILE(dlls/winepulse.drv)

--- a/dlls/mmdevapi/client.c
+++ b/dlls/mmdevapi/client.c
@@ -200,27 +200,11 @@ static void dump_fmt(const WAVEFORMATEX *fmt)
     }
 }
 
-static DWORD CALLBACK timer_loop_func(void *user)
-{
-    struct timer_loop_params params;
-    struct audio_client *This = user;
-
-    SetThreadDescription(GetCurrentThread(), L"audio_client_timer");
-
-    params.stream = This->stream;
-
-    wine_unix_call(timer_loop, &params);
-
-    return 0;
-}
-
-HRESULT stream_release(stream_handle stream, HANDLE timer_thread)
+static HRESULT stream_release(stream_handle stream)
 {
     struct release_stream_params params;
 
-    params.stream       = stream;
-    params.timer_thread = timer_thread;
-
+    params.stream = stream;
     wine_unix_call(release_stream, &params);
 
     return params.result;
@@ -562,7 +546,7 @@ static HRESULT stream_init(struct audio_client *client, const BOOLEAN force_def_
 
 exit:
     if (FAILED(params.result)) {
-        stream_release(stream, NULL);
+        stream_release(stream);
         free(client->vols);
         client->vols = NULL;
     } else {
@@ -750,7 +734,7 @@ static ULONG WINAPI client_Release(IAudioClient3 *iface)
         free(This->vols);
 
         if (This->stream)
-            stream_release(This->stream, This->timer_thread);
+            stream_release(This->stream);
 
         free(This->device_name);
         free(This);
@@ -943,15 +927,6 @@ static HRESULT WINAPI client_Start(IAudioClient3 *iface)
 
     params.stream = This->stream;
     wine_unix_call(start, &params);
-
-    if (SUCCEEDED(params.result) && !This->timer_thread) {
-        if ((This->timer_thread = CreateThread(NULL, 0, timer_loop_func, This, 0, NULL)))
-            SetThreadPriority(This->timer_thread, THREAD_PRIORITY_TIME_CRITICAL);
-        else {
-            IAudioClient3_Stop(&This->IAudioClient3_iface);
-            params.result = E_FAIL;
-        }
-    }
 
     sessions_unlock();
 

--- a/dlls/mmdevapi/client.c
+++ b/dlls/mmdevapi/client.c
@@ -50,16 +50,6 @@ extern HRESULT get_audio_session(const GUID *sessionguid, IMMDevice *device, UIN
                                  struct audio_session **out);
 extern struct audio_session_wrapper *session_wrapper_create(struct audio_client *client);
 
-static HANDLE main_loop_thread;
-
-void main_loop_stop(void)
-{
-    if (main_loop_thread) {
-        WaitForSingleObject(main_loop_thread, INFINITE);
-        CloseHandle(main_loop_thread);
-    }
-}
-
 void set_stream_volumes(struct audio_client *This)
 {
     struct set_volumes_params params;
@@ -208,37 +198,6 @@ static void dump_fmt(const WAVEFORMATEX *fmt)
         TRACE("Samples: %04x\n", fmtex->Samples.wReserved);
         TRACE("SubFormat: %s\n", wine_dbgstr_guid(&fmtex->SubFormat));
     }
-}
-
-static DWORD CALLBACK main_loop_func(void *event)
-{
-    struct main_loop_params params;
-
-    SetThreadDescription(GetCurrentThread(), L"audio_client_main");
-
-    params.event = event;
-
-    wine_unix_call(main_loop, &params);
-
-    return 0;
-}
-
-HRESULT main_loop_start(void)
-{
-    if (!main_loop_thread) {
-        HANDLE event = CreateEventW(NULL, TRUE, FALSE, NULL);
-        if (!(main_loop_thread = CreateThread(NULL, 0, main_loop_func, event, 0, NULL))) {
-            ERR("Failed to create main loop thread\n");
-            CloseHandle(event);
-            return E_FAIL;
-        }
-
-        SetThreadPriority(main_loop_thread, THREAD_PRIORITY_TIME_CRITICAL);
-        WaitForSingleObject(event, INFINITE);
-        CloseHandle(event);
-    }
-
-    return S_OK;
 }
 
 static DWORD CALLBACK timer_loop_func(void *user)
@@ -532,10 +491,7 @@ static HRESULT stream_init(struct audio_client *client, const BOOLEAN force_def_
         return AUDCLNT_E_ALREADY_INITIALIZED;
     }
 
-    if (FAILED(params.result = main_loop_start())) {
-        sessions_unlock();
-        return params.result;
-    }
+    wine_unix_call( main_loop_start, NULL );
 
     if (flags & AUDCLNT_STREAMFLAGS_LOOPBACK) {
         struct get_loopback_capture_device_params params;

--- a/dlls/mmdevapi/main.c
+++ b/dlls/mmdevapi/main.c
@@ -89,7 +89,7 @@ static BOOL load_driver(const WCHAR *name, DriverFuncs *driver)
         return FALSE;
     }
 
-    if ((status = NtQueryVirtualMemory(GetCurrentProcess(), driver->module, MemoryWineUnixFuncs,
+    if ((status = NtQueryVirtualMemory(GetCurrentProcess(), driver->module, MemoryWineLoadUnixLib,
         &driver->module_unixlib, sizeof(driver->module_unixlib), NULL))) {
         ERR("Unable to load UNIX functions: %lx\n", status);
         goto fail;

--- a/dlls/mmdevapi/main.c
+++ b/dlls/mmdevapi/main.c
@@ -74,25 +74,21 @@ static BOOL load_driver(const WCHAR *name, DriverFuncs *driver)
 {
     NTSTATUS status;
     WCHAR driver_module[264], path[MAX_PATH];
+    UNICODE_STRING str;
     struct test_connect_params params;
 
     lstrcpyW(driver_module, L"wine");
     lstrcatW(driver_module, name);
     lstrcatW(driver_module, L".drv");
+    RtlInitUnicodeString( &str, driver_module );
 
     TRACE("Attempting to load %s\n", wine_dbgstr_w(driver_module));
 
-    driver->module = LoadLibraryW(driver_module);
-    if(!driver->module){
-        TRACE("Unable to load %s: %lu\n", wine_dbgstr_w(driver_module),
-                GetLastError());
+    status = __wine_load_unix_lib( &str, &driver->module, &driver->module_unixlib );
+    if (status)
+    {
+        TRACE("Unable to load %s: %lx\n", wine_dbgstr_w(driver_module), status );
         return FALSE;
-    }
-
-    if ((status = NtQueryVirtualMemory(GetCurrentProcess(), driver->module, MemoryWineLoadUnixLib,
-        &driver->module_unixlib, sizeof(driver->module_unixlib), NULL))) {
-        ERR("Unable to load UNIX functions: %lx\n", status);
-        goto fail;
     }
 
     if ((status = __wine_unix_call(driver->module_unixlib, process_attach, NULL))) {
@@ -119,7 +115,7 @@ static BOOL load_driver(const WCHAR *name, DriverFuncs *driver)
 
     return TRUE;
 fail:
-    FreeLibrary(driver->module);
+    __wine_unload_unix_lib( driver->module );
     return FALSE;
 }
 
@@ -155,15 +151,15 @@ static BOOL WINAPI init_driver(INIT_ONCE *once, void *param, void **context)
         driver.priority = Priority_Unavailable;
         if(load_driver(p, &driver)){
             if(driver.priority == Priority_Unavailable)
-                FreeLibrary(driver.module);
+                __wine_unload_unix_lib(driver.module);
             else if(!drvs.module || driver.priority > drvs.priority){
                 TRACE("Selecting driver %s with priority %s\n",
                         wine_dbgstr_w(p), get_priority_string(driver.priority));
                 if(drvs.module)
-                    FreeLibrary(drvs.module);
+                    __wine_unload_unix_lib(drvs.module);
                 drvs = driver;
             }else
-                FreeLibrary(driver.module);
+                __wine_unload_unix_lib(driver.module);
         }else
             TRACE("Failed to load driver %s\n", wine_dbgstr_w(p));
 
@@ -212,17 +208,17 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
             if (drvs.module_unixlib)
             {
                 wine_unix_call( process_detach, NULL );
-                FreeLibrary( drvs.module );
-                if (midi_driver.module != drvs.module)
-                {
-                    MIDI_CALL( process_detach, NULL );
-                    FreeLibrary( midi_driver.module );
-                }
+                if (midi_driver.module != drvs.module) MIDI_CALL( process_detach, NULL );
             }
-            main_loop_stop();
+            if (lpvReserved) break;
 
-            if (!lpvReserved)
-                MMDevEnum_Free();
+            main_loop_stop();
+            if (drvs.module_unixlib)
+            {
+                __wine_unload_unix_lib( drvs.module );
+                if (midi_driver.module != drvs.module) __wine_unload_unix_lib( midi_driver.module );
+            }
+            MMDevEnum_Free();
             break;
     }
 

--- a/dlls/mmdevapi/main.c
+++ b/dlls/mmdevapi/main.c
@@ -212,7 +212,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
             }
             if (lpvReserved) break;
 
-            main_loop_stop();
+            wine_unix_call( main_loop_stop, NULL );
             if (drvs.module_unixlib)
             {
                 __wine_unload_unix_lib( drvs.module );

--- a/dlls/mmdevapi/main.c
+++ b/dlls/mmdevapi/main.c
@@ -121,7 +121,7 @@ fail:
 
 static BOOL WINAPI init_driver(INIT_ONCE *once, void *param, void **context)
 {
-    static WCHAR default_list[] = L"pulse,alsa,oss,coreaudio";
+    static WCHAR default_list[] = L"pipewire,pulse,alsa,oss,coreaudio";
     DriverFuncs driver;
     HKEY key;
     WCHAR reg_list[256], *p, *next, *driver_list = default_list;

--- a/dlls/mmdevapi/mmdevapi_private.h
+++ b/dlls/mmdevapi/mmdevapi_private.h
@@ -88,7 +88,7 @@ extern HRESULT MMDevEnum_Create(REFIID riid, void **ppv);
 extern void MMDevEnum_Free(void);
 
 typedef struct _DriverFuncs {
-    HMODULE module;
+    unixlib_module_t module;
     unixlib_handle_t module_unixlib;
     WCHAR module_name[64];
 

--- a/dlls/mmdevapi/mmdevapi_private.h
+++ b/dlls/mmdevapi/mmdevapi_private.h
@@ -75,8 +75,6 @@ struct audio_client {
     UINT32 channel_count;
     stream_handle stream;
 
-    HANDLE timer_thread;
-
     struct audio_session *session;
     struct audio_session_wrapper *session_wrapper;
 

--- a/dlls/mmdevapi/mmdevapi_private.h
+++ b/dlls/mmdevapi/mmdevapi_private.h
@@ -129,8 +129,6 @@ extern BOOL get_device_name_from_guid( const GUID *guid, char **name, EDataFlow 
 extern HRESULT load_devices_from_reg(void);
 extern HRESULT load_driver_devices(EDataFlow flow);
 
-extern void main_loop_stop(void);
-
 extern const WCHAR drv_keyW[];
 
 extern HRESULT get_audio_sessions(IMMDevice *device, GUID **ret, int *ret_count);

--- a/dlls/mmdevapi/unixlib.h
+++ b/dlls/mmdevapi/unixlib.h
@@ -83,7 +83,6 @@ struct create_stream_params
 struct release_stream_params
 {
     stream_handle stream;
-    HANDLE timer_thread;
     HRESULT result;
 };
 
@@ -103,11 +102,6 @@ struct reset_params
 {
     stream_handle stream;
     HRESULT result;
-};
-
-struct timer_loop_params
-{
-    stream_handle stream;
 };
 
 struct get_render_buffer_params
@@ -337,7 +331,6 @@ enum unix_funcs
     start,
     stop,
     reset,
-    timer_loop,
     get_render_buffer,
     release_render_buffer,
     get_capture_buffer,

--- a/dlls/mmdevapi/unixlib.h
+++ b/dlls/mmdevapi/unixlib.h
@@ -20,6 +20,25 @@
 #include "audioclient.h"
 #include "mmdeviceapi.h"
 
+#ifdef WINE_UNIX_LIB
+/* helper to create a thread on the Unix side */
+static inline NTSTATUS create_unix_thread( HANDLE *handle, const WCHAR *name,
+                                           void (*entry)(void *), void *param )
+{
+    DWORD priority = THREAD_PRIORITY_TIME_CRITICAL;
+    THREAD_NAME_INFORMATION info;
+    NTSTATUS status;
+
+    if (!(status = PsCreateSystemThread( handle, THREAD_ALL_ACCESS, NULL, 0, NULL, entry, param )))
+    {
+        RtlInitUnicodeString( &info.ThreadName, name );
+        NtSetInformationThread( *handle, ThreadNameInformation, &info, sizeof(info) );
+        NtSetInformationThread( *handle, ThreadBasePriority, &priority, sizeof(priority) );
+    }
+    return status;
+}
+#endif
+
 typedef UINT64 stream_handle;
 
 enum driver_priority
@@ -34,11 +53,6 @@ struct endpoint
 {
     unsigned int name;
     unsigned int device;
-};
-
-struct main_loop_params
-{
-    HANDLE event;
 };
 
 struct get_endpoint_ids_params
@@ -315,7 +329,8 @@ enum unix_funcs
 {
     process_attach,
     process_detach,
-    main_loop,
+    main_loop_start,
+    main_loop_stop,
     get_endpoint_ids,
     create_stream,
     release_stream,

--- a/dlls/ntdll/unix/loader.c
+++ b/dlls/ntdll/unix/loader.c
@@ -1785,6 +1785,78 @@ NTSTATUS load_builtin( const struct pe_image_info *image_info, UNICODE_STRING *n
 }
 
 
+/***********************************************************************
+ *           load_unixlib_by_name
+ */
+NTSTATUS load_unixlib_by_name( const UNICODE_STRING *nt_name, void **handle_ret )
+{
+    unsigned int i, pos, namepos, maxlen = 0;
+    unsigned int len = nt_name->Length / sizeof(WCHAR);
+    const char *so_dir = get_so_dir( current_machine );
+    char *ptr = NULL, *file, *ext = NULL;
+    void *handle = NULL;
+
+    if (!len) return STATUS_DLL_NOT_FOUND;
+
+    for (i = namepos = 0; i < len; i++)
+        if (nt_name->Buffer[i] == '/' || nt_name->Buffer[i] == '\\') break;
+
+    if (i < len)  /* explicit path */
+    {
+        UNICODE_STRING true_nt_name;
+        OBJECT_ATTRIBUTES attr;
+
+        InitializeObjectAttributes( &attr, (UNICODE_STRING *)nt_name, 0, 0, NULL );
+        if (!get_nt_and_unix_names( &attr, &true_nt_name, &file, FILE_OPEN, FALSE ))
+            handle = dlopen( file, RTLD_NOW );
+        free( true_nt_name.Buffer );
+        goto done;
+    }
+
+    if (build_dir) maxlen = strlen(build_dir) + sizeof("/dlls/") + len;
+    maxlen = max( maxlen, dll_path_maxlen + 1 ) + len + sizeof("/aarch64-unix") + sizeof(".so");
+
+    if (!(file = malloc( maxlen ))) return STATUS_NO_MEMORY;
+
+    pos = maxlen - len - 4;
+    /* we don't want to depend on the current codepage here */
+    for (i = 0; i < len; i++)
+    {
+        if (nt_name->Buffer[namepos + i] > 127) goto done;
+        file[pos + i] = (char)nt_name->Buffer[namepos + i];
+        if (file[pos + i] >= 'A' && file[pos + i] <= 'Z') file[pos + i] += 'a' - 'A';
+        else if (file[pos + i] == '.') ext = file + pos + i;
+    }
+    file[pos + len] = 0;
+    file[--pos] = '/';
+    if (!ext) ext = file + pos + len;
+
+    if (build_dir)
+    {
+        ptr = prepend_build_dir_path( file + pos, ".so", "", "/dlls", build_dir );
+        strcpy( ext, ".so" );
+        if ((handle = dlopen( ptr, RTLD_NOW ))) goto done;
+    }
+
+    strcpy( ext, ".so" );
+    for (i = 0; dll_paths[i]; i++)
+    {
+        ptr = prepend( file + pos, so_dir, strlen(so_dir) );
+        ptr = prepend( ptr, dll_paths[i], strlen(dll_paths[i]) );
+        if ((handle = dlopen( ptr, RTLD_NOW ))) goto done;
+
+        ptr = prepend( file + pos, dll_paths[i], strlen(dll_paths[i]) );
+        if ((handle = dlopen( ptr, RTLD_NOW ))) goto done;
+    }
+
+ done:
+    free( file );
+    if (!handle) return STATUS_DLL_NOT_FOUND;
+    *handle_ret = handle;
+    return STATUS_SUCCESS;
+}
+
+
 /***************************************************************************
  *	get_machine_wow64_dir
  *

--- a/dlls/ntdll/unix/loader.c
+++ b/dlls/ntdll/unix/loader.c
@@ -1728,7 +1728,7 @@ done:
     if (NT_SUCCESS(status) && ext)
     {
         strcpy( ext, ".so" );
-        load_builtin_unixlib( *module, ptr );
+        set_builtin_unixlib_name( *module, ptr );
     }
     free( file );
     return status;

--- a/dlls/ntdll/unix/signal_x86_64.c
+++ b/dlls/ntdll/unix/signal_x86_64.c
@@ -2914,7 +2914,8 @@ static void quit_handler( int signal, siginfo_t *siginfo, void *sigcontext )
 {
     ucontext_t *ucontext = init_handler( sigcontext );
 
-    if (!is_inside_syscall( RSP_sig(ucontext) )) user_mode_abort_thread( 0, get_syscall_frame() );
+    if (!ntdll_get_thread_data()->system_thread && !is_inside_syscall( RSP_sig(ucontext) ))
+        user_mode_abort_thread( 0, get_syscall_frame() );
     abort_thread( 0 );
 }
 
@@ -2928,7 +2929,11 @@ static void usr1_handler( int signal, siginfo_t *siginfo, void *sigcontext )
 {
     ucontext_t *ucontext = init_handler( sigcontext );
 
-    if (is_inside_syscall( RSP_sig(ucontext) ))
+    if (ntdll_get_thread_data()->system_thread)
+    {
+        server_select( NULL, 0, SELECT_INTERRUPTIBLE, 0, NULL, NULL );
+    }
+    else if (is_inside_syscall( RSP_sig(ucontext) ))
     {
         struct syscall_frame *frame = get_syscall_frame();
         ULONG64 saved_compaction = 0;

--- a/dlls/ntdll/unix/thread.c
+++ b/dlls/ntdll/unix/thread.c
@@ -1470,6 +1470,129 @@ done:
 
 
 /***********************************************************************
+ *           start_system_thread
+ *
+ * Startup routine for a thread that runs entirely on the Unix side.
+ */
+static void start_system_thread( TEB *teb )
+{
+    struct ntdll_thread_data *thread_data = (struct ntdll_thread_data *)&teb->GdiTebBatch;
+    BOOL suspend;
+
+    thread_data->syscall_table = KeServiceDescriptorTable;
+    thread_data->syscall_trace = TRACE_ON(syscall);
+    thread_data->pthread_id = pthread_self();
+    thread_data->system_thread = TRUE;
+    pthread_setspecific( teb_key, teb );
+    server_init_thread( NULL, &suspend );
+    pthread_sigmask( SIG_UNBLOCK, &server_block_set, NULL );
+    thread_data->start( thread_data->param );
+    PsTerminateSystemThread( 0 );
+}
+
+
+/***********************************************************************
+ *              PsCreateSystemThread   (ntdll.so)
+ */
+NTSTATUS WINAPI PsCreateSystemThread( HANDLE *handle, ACCESS_MASK access, OBJECT_ATTRIBUTES *attr,
+                                      HANDLE process, CLIENT_ID *id, PRTL_THREAD_START_ROUTINE start, void *param )
+{
+    sigset_t sigset;
+    pthread_t pthread_id;
+    pthread_attr_t pthread_attr;
+    data_size_t len;
+    struct object_attributes *objattr;
+    struct ntdll_thread_data *thread_data;
+    INITIAL_TEB stack;
+    DWORD tid = 0;
+    int request_pipe[2];
+    TEB *teb;
+    unsigned int status;
+
+    if ((status = alloc_object_attributes( attr, &objattr, &len ))) return status;
+
+    if (server_pipe( request_pipe ) == -1)
+    {
+        free( objattr );
+        return STATUS_TOO_MANY_OPENED_FILES;
+    }
+    wine_server_send_fd( request_pipe[0] );
+
+    if (!access) access = THREAD_ALL_ACCESS;
+
+    SERVER_START_REQ( new_thread )
+    {
+        req->process    = wine_server_obj_handle( NtCurrentProcess() );
+        req->access     = access;
+        req->flags      = THREAD_CREATE_FLAGS_BYPASS_PROCESS_FREEZE;
+        req->request_fd = request_pipe[0];
+        wine_server_add_data( req, objattr, len );
+        if (!(status = wine_server_call( req )))
+        {
+            *handle = wine_server_ptr_handle( reply->handle );
+            tid = reply->tid;
+        }
+        close( request_pipe[0] );
+    }
+    SERVER_END_REQ;
+
+    free( objattr );
+    if (status)
+    {
+        close( request_pipe[1] );
+        return status;
+    }
+
+    pthread_sigmask( SIG_BLOCK, &server_block_set, &sigset );
+
+    if ((status = virtual_alloc_teb( &teb ))) goto done;
+
+    /* kernel stack only, system threads never run PE code */
+    if ((status = virtual_alloc_thread_stack( &stack, limit_4g, 0, kernel_stack_size, kernel_stack_size, FALSE )))
+    {
+        virtual_free_teb( teb );
+        goto done;
+    }
+
+    set_thread_id( teb, GetCurrentProcessId(), tid );
+
+    thread_data = (struct ntdll_thread_data *)&teb->GdiTebBatch;
+    thread_data->request_fd   = request_pipe[1];
+    thread_data->kernel_stack = stack.DeallocationStack;
+    thread_data->start = start;
+    thread_data->param = param;
+
+    pthread_attr_init( &pthread_attr );
+    pthread_attr_setstack( &pthread_attr, thread_data->kernel_stack, kernel_stack_size );
+    pthread_attr_setguardsize( &pthread_attr, 0 );
+    pthread_attr_setscope( &pthread_attr, PTHREAD_SCOPE_SYSTEM ); /* force creating a kernel thread */
+    InterlockedIncrement( &nb_threads );
+    if (pthread_create( &pthread_id, &pthread_attr, (void * (*)(void *))start_system_thread, teb ))
+    {
+        InterlockedDecrement( &nb_threads );
+        virtual_free_teb( teb );
+        status = STATUS_NO_MEMORY;
+    }
+    pthread_attr_destroy( &pthread_attr );
+
+done:
+    pthread_sigmask( SIG_SETMASK, &sigset, NULL );
+    if (status)
+    {
+        NtClose( *handle );
+        close( request_pipe[1] );
+        return status;
+    }
+    if (id)
+    {
+        id->UniqueProcess = ULongToHandle( GetCurrentProcessId() );
+        id->UniqueThread  = ULongToHandle( tid );
+    }
+    return status;
+}
+
+
+/***********************************************************************
  *           abort_thread
  */
 void abort_thread( int status )
@@ -1767,6 +1890,15 @@ NTSTATUS WINAPI NtTerminateThread( HANDLE handle, LONG exit_code )
         exit_thread( exit_code );
     }
     return ret;
+}
+
+
+/******************************************************************************
+ *              PsTerminateSystemThread  (ntdll.so)
+ */
+NTSTATUS WINAPI PsTerminateSystemThread( NTSTATUS exit_code )
+{
+    for (;;) exit_thread( exit_code );
 }
 
 

--- a/dlls/ntdll/unix/unix_private.h
+++ b/dlls/ntdll/unix/unix_private.h
@@ -332,7 +332,7 @@ extern void virtual_set_large_address_space(void);
 extern void virtual_fill_image_information( const struct pe_image_info *pe_info,
                                             SECTION_IMAGE_INFORMATION *info );
 extern void *get_builtin_so_handle( void *module );
-extern NTSTATUS load_builtin_unixlib( void *module, const char *name );
+extern NTSTATUS set_builtin_unixlib_name( void *module, const char *name );
 
 extern NTSTATUS get_thread_ldt_entry( HANDLE handle, THREAD_DESCRIPTOR_INFORMATION *info, ULONG len );
 extern void *get_native_context( CONTEXT *context );

--- a/dlls/ntdll/unix/unix_private.h
+++ b/dlls/ntdll/unix/unix_private.h
@@ -232,6 +232,7 @@ extern NTSTATUS exec_wineloader( char **argv, int socketfd, const struct pe_imag
 extern NTSTATUS load_builtin( const struct pe_image_info *image_info, UNICODE_STRING *nt_name,
                               ANSI_STRING *exp_name, USHORT machine, SECTION_IMAGE_INFORMATION *info,
                               void **module, SIZE_T *size, ULONG_PTR limit_low, ULONG_PTR limit_high, off_t offset );
+extern NTSTATUS load_unixlib_by_name( const UNICODE_STRING *nt_name, void **handle_ret );
 extern BOOL is_builtin_path( const UNICODE_STRING *path, WORD *machine );
 extern NTSTATUS load_main_exe( UNICODE_STRING *nt_name, USHORT load_machine, void **module );
 extern NTSTATUS load_start_exe( UNICODE_STRING *nt_name, void **module );

--- a/dlls/ntdll/unix/unix_private.h
+++ b/dlls/ntdll/unix/unix_private.h
@@ -116,6 +116,7 @@ struct ntdll_thread_data
     PRTL_THREAD_START_ROUTINE start;         /* thread entry point */
     void                     *param;         /* thread entry point parameter */
     void                     *jmp_buf;       /* setjmp buffer for exception handling */
+    BOOL                      system_thread; /* thread runs only on the Unix side */
     int                      *fsync_apc_futex;
 };
 

--- a/dlls/ntdll/unix/virtual.c
+++ b/dlls/ntdll/unix/virtual.c
@@ -6660,6 +6660,37 @@ NTSTATUS WINAPI NtQueryVirtualMemory( HANDLE process, LPCVOID addr,
             }
             return STATUS_INVALID_HANDLE;
 
+        case MemoryWineLoadUnixLibByName:
+        case MemoryWineLoadUnixLibByNameWow64:
+            if (process == GetCurrentProcess())
+            {
+                UINT64 res[2];
+                const UNICODE_STRING *name = addr;
+                const void *funcs;
+                void *handle;
+
+                if ((status = load_unixlib_by_name( name, &handle ))) return status;
+                res[0] = (UINT_PTR)handle;
+                if (len >= sizeof(res))
+                {
+                    if (!(status = get_unixlib_funcs( handle, info_class == MemoryWineLoadUnixLibByNameWow64, &funcs )))
+                        res[1] = (UINT_PTR)funcs;
+                }
+                if (status) dlclose( handle );
+                else memcpy( buffer, res, min( len, sizeof(res) ));
+                return status;
+            }
+            return STATUS_INVALID_HANDLE;
+
+        case MemoryWineUnloadUnixLib:
+            if (process == GetCurrentProcess())
+            {
+                const unixlib_module_t *handle = addr;
+
+                if (!dlclose( (void *)(UINT_PTR)*handle )) return STATUS_SUCCESS;
+            }
+            return STATUS_INVALID_HANDLE;
+
         case MemoryFexStatsShm:
 #if defined(linux) && defined(__aarch64__)
             return get_memory_fex_stats_shm( process, addr, buffer, len, res_len );

--- a/dlls/ntdll/unix/virtual.c
+++ b/dlls/ntdll/unix/virtual.c
@@ -999,11 +999,22 @@ static void load_steam_overlay(const char *unix_lib_path)
 }
 
 /***********************************************************************
+ *           get_unixlib_funcs
+ */
+static NTSTATUS get_unixlib_funcs( void *so_handle, BOOL wow, const void **funcs )
+{
+    const char *name = wow ? "__wine_unix_call_wow64_funcs" : "__wine_unix_call_funcs";
+
+    *funcs = dlsym( so_handle, name );
+    return *funcs ? STATUS_SUCCESS : STATUS_ENTRYPOINT_NOT_FOUND;
+}
+
+
+/***********************************************************************
  *           load_builtin_unixlib
  */
 static NTSTATUS load_builtin_unixlib( void *module, BOOL wow, const void **funcs )
 {
-    const char *ptr_name = wow ? "__wine_unix_call_wow64_funcs" : "__wine_unix_call_funcs";
     sigset_t sigset;
     NTSTATUS status = STATUS_DLL_NOT_FOUND;
     struct builtin_module *builtin;
@@ -1018,11 +1029,7 @@ static NTSTATUS load_builtin_unixlib( void *module, BOOL wow, const void **funcs
             if (!builtin->unix_handle)
                 WARN_(module)( "failed to load %s: %s\n", debugstr_a(builtin->unix_path), dlerror() );
         }
-        if (builtin->unix_handle)
-        {
-            *funcs = dlsym( builtin->unix_handle, ptr_name );
-            status = *funcs ? STATUS_SUCCESS : STATUS_ENTRYPOINT_NOT_FOUND;
-        }
+        if (builtin->unix_handle) status = get_unixlib_funcs( builtin->unix_handle, wow, funcs );
     }
     server_leave_uninterrupted_section( &virtual_mutex, &sigset );
     return status;

--- a/dlls/ntdll/unix/virtual.c
+++ b/dlls/ntdll/unix/virtual.c
@@ -993,9 +993,9 @@ static void load_steam_overlay(const char *unix_lib_path)
 }
 
 /***********************************************************************
- *           get_builtin_unix_funcs
+ *           load_builtin_unixlib
  */
-static NTSTATUS get_builtin_unix_funcs( void *module, BOOL wow, const void **funcs )
+static NTSTATUS load_builtin_unixlib( void *module, BOOL wow, const void **funcs )
 {
     const char *ptr_name = wow ? "__wine_unix_call_wow64_funcs" : "__wine_unix_call_funcs";
     sigset_t sigset;
@@ -1026,9 +1026,9 @@ static NTSTATUS get_builtin_unix_funcs( void *module, BOOL wow, const void **fun
 
 
 /***********************************************************************
- *           load_builtin_unixlib
+ *           set_builtin_unixlib_name
  */
-NTSTATUS load_builtin_unixlib( void *module, const char *name )
+NTSTATUS set_builtin_unixlib_name( void *module, const char *name )
 {
     sigset_t sigset;
     NTSTATUS status = STATUS_SUCCESS;
@@ -6637,15 +6637,15 @@ NTSTATUS WINAPI NtQueryVirtualMemory( HANDLE process, LPCVOID addr,
         case MemoryImageInformation:
             return get_memory_image_info( process, addr, buffer, len, res_len );
 
-        case MemoryWineUnixFuncs:
-        case MemoryWineUnixWow64Funcs:
+        case MemoryWineLoadUnixLib:
+        case MemoryWineLoadUnixLibWow64:
             if (len != sizeof(unixlib_handle_t)) return STATUS_INFO_LENGTH_MISMATCH;
             if (process == GetCurrentProcess())
             {
                 void *module = (void *)addr;
                 const void *funcs = NULL;
 
-                status = get_builtin_unix_funcs( module, info_class == MemoryWineUnixWow64Funcs, &funcs );
+                status = load_builtin_unixlib( module, info_class == MemoryWineLoadUnixLibWow64, &funcs );
                 if (!status) *(unixlib_handle_t *)buffer = (UINT_PTR)funcs;
                 return status;
             }

--- a/dlls/ntdll/unix/virtual.c
+++ b/dlls/ntdll/unix/virtual.c
@@ -924,25 +924,33 @@ static void add_builtin_module( void *module, void *handle )
 
 
 /***********************************************************************
- *           release_builtin_module
+ *           get_builtin_module
  */
-static void release_builtin_module( void *module )
+static struct builtin_module *get_builtin_module( void *module )
 {
     struct builtin_module *builtin;
 
     LIST_FOR_EACH_ENTRY( builtin, &builtin_modules, struct builtin_module, entry )
-    {
-        if (builtin->module != module) continue;
-        if (!--builtin->refcount)
-        {
-            list_remove( &builtin->entry );
-            if (builtin->handle) dlclose( builtin->handle );
-            if (builtin->unix_handle) dlclose( builtin->unix_handle );
-            free( builtin->unix_path );
-            free( builtin );
-        }
-        break;
-    }
+        if (builtin->module == module) return builtin;
+
+    return NULL;
+}
+
+
+/***********************************************************************
+ *           release_builtin_module
+ */
+static void release_builtin_module( void *module )
+{
+    struct builtin_module *builtin = get_builtin_module( module );
+
+    if (!builtin) return;
+    if (--builtin->refcount) return;
+    list_remove( &builtin->entry );
+    if (builtin->handle) dlclose( builtin->handle );
+    if (builtin->unix_handle) dlclose( builtin->unix_handle );
+    free( builtin->unix_path );
+    free( builtin );
 }
 
 
@@ -956,12 +964,10 @@ void *get_builtin_so_handle( void *module )
     struct builtin_module *builtin;
 
     server_enter_uninterrupted_section( &virtual_mutex, &sigset );
-    LIST_FOR_EACH_ENTRY( builtin, &builtin_modules, struct builtin_module, entry )
+    if ((builtin = get_builtin_module( module )))
     {
-        if (builtin->module != module) continue;
         ret = builtin->handle;
         if (ret) builtin->refcount++;
-        break;
     }
     server_leave_uninterrupted_section( &virtual_mutex, &sigset );
     return ret;
@@ -1003,9 +1009,8 @@ static NTSTATUS load_builtin_unixlib( void *module, BOOL wow, const void **funcs
     struct builtin_module *builtin;
 
     server_enter_uninterrupted_section( &virtual_mutex, &sigset );
-    LIST_FOR_EACH_ENTRY( builtin, &builtin_modules, struct builtin_module, entry )
+    if ((builtin = get_builtin_module( module )))
     {
-        if (builtin->module != module) continue;
         if (builtin->unix_path && !builtin->unix_handle)
         {
             load_steam_overlay(builtin->unix_path);
@@ -1018,7 +1023,6 @@ static NTSTATUS load_builtin_unixlib( void *module, BOOL wow, const void **funcs
             *funcs = dlsym( builtin->unix_handle, ptr_name );
             status = *funcs ? STATUS_SUCCESS : STATUS_ENTRYPOINT_NOT_FOUND;
         }
-        break;
     }
     server_leave_uninterrupted_section( &virtual_mutex, &sigset );
     return status;
@@ -1035,9 +1039,8 @@ NTSTATUS set_builtin_unixlib_name( void *module, const char *name )
     struct builtin_module *builtin;
 
     server_enter_uninterrupted_section( &virtual_mutex, &sigset );
-    LIST_FOR_EACH_ENTRY( builtin, &builtin_modules, struct builtin_module, entry )
+    if ((builtin = get_builtin_module( module )))
     {
-        if (builtin->module != module) continue;
         if (!builtin->unix_path) builtin->unix_path = strdup( name );
         else status = STATUS_IMAGE_ALREADY_LOADED;
         if (!builtin->unix_handle)
@@ -1045,7 +1048,6 @@ NTSTATUS set_builtin_unixlib_name( void *module, const char *name )
             load_steam_overlay(builtin->unix_path);
             builtin->unix_handle = dlopen( builtin->unix_path, RTLD_NOW );
         }
-        break;
     }
     server_leave_uninterrupted_section( &virtual_mutex, &sigset );
     return status;
@@ -6931,18 +6933,14 @@ static NTSTATUS unmap_view_of_section( HANDLE process, PVOID addr, ULONG flags )
     }
     if (view->protect & VPROT_SYSTEM)
     {
-        struct builtin_module *builtin;
+        struct builtin_module *builtin = get_builtin_module( view->base );
 
-        LIST_FOR_EACH_ENTRY( builtin, &builtin_modules, struct builtin_module, entry )
+        if (builtin && builtin->refcount > 1)
         {
-            if (builtin->module != view->base) continue;
-            if (builtin->refcount > 1)
-            {
-                TRACE( "not freeing in-use builtin %p\n", view->base );
-                builtin->refcount--;
-                server_leave_uninterrupted_section( &virtual_mutex, &sigset );
-                return STATUS_SUCCESS;
-            }
+            TRACE( "not freeing in-use builtin %p\n", view->base );
+            builtin->refcount--;
+            server_leave_uninterrupted_section( &virtual_mutex, &sigset );
+            return STATUS_SUCCESS;
         }
     }
 

--- a/dlls/winealsa.drv/Makefile.in
+++ b/dlls/winealsa.drv/Makefile.in
@@ -1,7 +1,4 @@
-MODULE    = winealsa.drv
 UNIXLIB   = winealsa.so
-IMPORTS   = uuid ole32 advapi32
-DELAYIMPORTS = winmm
 UNIX_CFLAGS  = $(ALSA_CFLAGS)
 UNIX_LIBS    = $(ALSA_LIBS) $(PTHREAD_LIBS)
 

--- a/dlls/winealsa.drv/alsa.c
+++ b/dlls/winealsa.drv/alsa.c
@@ -59,6 +59,7 @@ struct alsa_stream
     AUDCLNT_SHAREMODE share;
     EDataFlow flow;
     HANDLE event;
+    HANDLE timer_thread;
 
     BOOL need_remapping;
     int alsa_channels;
@@ -1033,10 +1034,10 @@ static NTSTATUS alsa_release_stream(void *args)
     struct alsa_stream *stream = handle_get_stream(params->stream);
     SIZE_T size;
 
-    if(params->timer_thread){
+    if(stream->timer_thread){
         stream->please_quit = TRUE;
-        NtWaitForSingleObject(params->timer_thread, FALSE, NULL);
-        NtClose(params->timer_thread);
+        NtWaitForSingleObject(stream->timer_thread, FALSE, NULL);
+        NtClose(stream->timer_thread);
     }
 
     snd_pcm_drop(stream->pcm_handle);
@@ -1523,10 +1524,46 @@ static int alsa_rewind_best_effort(struct alsa_stream *stream)
     return len;
 }
 
+static void alsa_timer_loop(void *args)
+{
+    struct alsa_stream *stream = args;
+    LARGE_INTEGER delay, next;
+    int adjust;
+
+    alsa_lock(stream);
+
+    delay.QuadPart = -stream->mmdev_period_rt;
+    NtQueryPerformanceCounter(&stream->last_period_time, NULL);
+    next.QuadPart = stream->last_period_time.QuadPart + stream->mmdev_period_rt;
+
+    while(!stream->please_quit){
+        if(stream->flow == eRender)
+            alsa_write_data(stream);
+        else if(stream->flow == eCapture)
+            alsa_read_data(stream);
+        alsa_unlock(stream);
+
+        NtDelayExecution(FALSE, &delay);
+
+        alsa_lock(stream);
+        NtQueryPerformanceCounter(&stream->last_period_time, NULL);
+        adjust = next.QuadPart - stream->last_period_time.QuadPart;
+        if(adjust > stream->mmdev_period_rt / 2)
+            adjust = stream->mmdev_period_rt / 2;
+        else if(adjust < -stream->mmdev_period_rt / 2)
+            adjust = -stream->mmdev_period_rt / 2;
+        delay.QuadPart = -(stream->mmdev_period_rt + adjust);
+        next.QuadPart += stream->mmdev_period_rt;
+    }
+
+    alsa_unlock(stream);
+}
+
 static NTSTATUS alsa_start(void *args)
 {
     struct start_params *params = args;
     struct alsa_stream *stream = handle_get_stream(params->stream);
+    static const WCHAR name[] = {'a','u','d','i','o','_','c','l','i','e','n','t','_','t','i','m','e','r',0};
 
     alsa_lock(stream);
 
@@ -1564,6 +1601,7 @@ static NTSTATUS alsa_start(void *args)
             stream->data_in_alsa_frames = 0;
         }
     }
+    if (!stream->timer_thread) create_unix_thread( &stream->timer_thread, name, alsa_timer_loop, stream );
     stream->started = TRUE;
 
     return alsa_unlock_result(stream, &params->result, S_OK);
@@ -1620,44 +1658,6 @@ static NTSTATUS alsa_reset(void *args)
     stream->wri_offs_frames = 0;
 
     return alsa_unlock_result(stream, &params->result, S_OK);
-}
-
-static NTSTATUS alsa_timer_loop(void *args)
-{
-    struct timer_loop_params *params = args;
-    struct alsa_stream *stream = handle_get_stream(params->stream);
-    LARGE_INTEGER delay, next;
-    int adjust;
-
-    alsa_lock(stream);
-
-    delay.QuadPart = -stream->mmdev_period_rt;
-    NtQueryPerformanceCounter(&stream->last_period_time, NULL);
-    next.QuadPart = stream->last_period_time.QuadPart + stream->mmdev_period_rt;
-
-    while(!stream->please_quit){
-        if(stream->flow == eRender)
-            alsa_write_data(stream);
-        else if(stream->flow == eCapture)
-            alsa_read_data(stream);
-        alsa_unlock(stream);
-
-        NtDelayExecution(FALSE, &delay);
-
-        alsa_lock(stream);
-        NtQueryPerformanceCounter(&stream->last_period_time, NULL);
-        adjust = next.QuadPart - stream->last_period_time.QuadPart;
-        if(adjust > stream->mmdev_period_rt / 2)
-            adjust = stream->mmdev_period_rt / 2;
-        else if(adjust < -stream->mmdev_period_rt / 2)
-            adjust = -stream->mmdev_period_rt / 2;
-        delay.QuadPart = -(stream->mmdev_period_rt + adjust);
-        next.QuadPart += stream->mmdev_period_rt;
-    }
-
-    alsa_unlock(stream);
-
-    return STATUS_SUCCESS;
 }
 
 static NTSTATUS alsa_get_render_buffer(void *args)
@@ -2420,7 +2420,6 @@ const unixlib_entry_t __wine_unix_call_funcs[] =
     alsa_start,
     alsa_stop,
     alsa_reset,
-    alsa_timer_loop,
     alsa_get_render_buffer,
     alsa_release_render_buffer,
     alsa_get_capture_buffer,
@@ -2520,13 +2519,11 @@ static NTSTATUS alsa_wow64_release_stream(void *args)
     struct
     {
         stream_handle stream;
-        PTR32 timer_thread;
         HRESULT result;
     } *params32 = args;
     struct release_stream_params params =
     {
         .stream = params32->stream,
-        .timer_thread = ULongToHandle(params32->timer_thread)
     };
     alsa_release_stream(&params);
     params32->result = params.result;
@@ -2865,7 +2862,6 @@ const unixlib_entry_t __wine_unix_call_wow64_funcs[] =
     alsa_start,
     alsa_stop,
     alsa_reset,
-    alsa_timer_loop,
     alsa_wow64_get_render_buffer,
     alsa_release_render_buffer,
     alsa_wow64_get_capture_buffer,

--- a/dlls/winealsa.drv/alsa.c
+++ b/dlls/winealsa.drv/alsa.c
@@ -492,13 +492,6 @@ static NTSTATUS alsa_process_attach(void *args)
     return STATUS_SUCCESS;
 }
 
-static NTSTATUS alsa_main_loop(void *args)
-{
-    struct main_loop_params *params = args;
-    NtSetEvent(params->event, NULL);
-    return STATUS_SUCCESS;
-}
-
 static NTSTATUS alsa_get_endpoint_ids(void *args)
 {
     static const WCHAR defaultW[] = {'d','e','f','a','u','l','t',0};
@@ -2419,7 +2412,8 @@ const unixlib_entry_t __wine_unix_call_funcs[] =
 {
     alsa_process_attach,
     alsa_not_implemented,
-    alsa_main_loop,
+    alsa_not_implemented,
+    alsa_not_implemented,
     alsa_get_endpoint_ids,
     alsa_create_stream,
     alsa_release_stream,
@@ -2461,19 +2455,6 @@ C_ASSERT(ARRAYSIZE(__wine_unix_call_funcs) == funcs_count);
 #ifdef _WIN64
 
 typedef UINT PTR32;
-
-static NTSTATUS alsa_wow64_main_loop(void *args)
-{
-    struct
-    {
-        PTR32 event;
-    } *params32 = args;
-    struct main_loop_params params =
-    {
-        .event = ULongToHandle(params32->event)
-    };
-    return alsa_main_loop(&params);
-}
 
 static NTSTATUS alsa_wow64_get_endpoint_ids(void *args)
 {
@@ -2876,7 +2857,8 @@ const unixlib_entry_t __wine_unix_call_wow64_funcs[] =
 {
     alsa_process_attach,
     alsa_not_implemented,
-    alsa_wow64_main_loop,
+    alsa_not_implemented,
+    alsa_not_implemented,
     alsa_wow64_get_endpoint_ids,
     alsa_wow64_create_stream,
     alsa_wow64_release_stream,

--- a/dlls/winecoreaudio.drv/Makefile.in
+++ b/dlls/winecoreaudio.drv/Makefile.in
@@ -1,8 +1,5 @@
-MODULE    = winecoreaudio.drv
 UNIXLIB   = winecoreaudio.so
-IMPORTS   = uuid ole32 user32 advapi32
-DELAYIMPORTS = winmm
-UNIX_LIBS    = $(COREAUDIO_LIBS)
+UNIX_LIBS = $(COREAUDIO_LIBS)
 
 SOURCES = \
 	coreaudio.c \

--- a/dlls/winecoreaudio.drv/coreaudio.c
+++ b/dlls/winecoreaudio.drv/coreaudio.c
@@ -214,13 +214,6 @@ static NTSTATUS unix_process_attach(void *args)
     return STATUS_SUCCESS;
 }
 
-static NTSTATUS unix_main_loop(void *args)
-{
-    struct main_loop_params *params = args;
-    NtSetEvent(params->event, NULL);
-    return STATUS_SUCCESS;
-}
-
 static NTSTATUS unix_get_endpoint_ids(void *args)
 {
     struct get_endpoint_ids_params *params = args;
@@ -1782,7 +1775,8 @@ const unixlib_entry_t __wine_unix_call_funcs[] =
 {
     unix_process_attach,
     unix_not_implemented,
-    unix_main_loop,
+    unix_not_implemented,
+    unix_not_implemented,
     unix_get_endpoint_ids,
     unix_create_stream,
     unix_release_stream,
@@ -1824,19 +1818,6 @@ C_ASSERT(ARRAYSIZE(__wine_unix_call_funcs) == funcs_count);
 #ifdef _WIN64
 
 typedef UINT PTR32;
-
-static NTSTATUS unix_wow64_main_loop(void *args)
-{
-    struct
-    {
-        PTR32 event;
-    } *params32 = args;
-    struct main_loop_params params =
-    {
-        .event = ULongToHandle(params32->event)
-    };
-    return unix_main_loop(&params);
-}
 
 static NTSTATUS unix_wow64_get_endpoint_ids(void *args)
 {
@@ -2238,7 +2219,8 @@ const unixlib_entry_t __wine_unix_call_wow64_funcs[] =
 {
     unix_process_attach,
     unix_not_implemented,
-    unix_wow64_main_loop,
+    unix_not_implemented,
+    unix_not_implemented,
     unix_wow64_get_endpoint_ids,
     unix_wow64_create_stream,
     unix_wow64_release_stream,

--- a/dlls/winecoreaudio.drv/coreaudio.c
+++ b/dlls/winecoreaudio.drv/coreaudio.c
@@ -88,6 +88,7 @@ struct coreaudio_stream
     DWORD flags;
     AUDCLNT_SHAREMODE share;
     HANDLE event;
+    HANDLE timer_thread;
 
     BOOL playing, please_quit;
     REFERENCE_TIME period;
@@ -818,10 +819,10 @@ static NTSTATUS unix_release_stream( void *args )
     struct coreaudio_stream *stream = handle_get_stream(params->stream);
     SIZE_T size;
 
-    if(params->timer_thread){
+    if(stream->timer_thread){
         stream->please_quit = TRUE;
-        NtWaitForSingleObject(params->timer_thread, FALSE, NULL);
-        NtClose(params->timer_thread);
+        NtWaitForSingleObject(stream->timer_thread, FALSE, NULL);
+        NtClose(stream->timer_thread);
     }
 
     if(stream->unit){
@@ -1349,10 +1350,37 @@ static NTSTATUS unix_get_current_padding(void *args)
     return STATUS_SUCCESS;
 }
 
+static void unix_timer_loop(void *args)
+{
+    struct coreaudio_stream *stream = args;
+    LARGE_INTEGER delay, next, last;
+    int adjust;
+
+    delay.QuadPart = -stream->period;
+    NtQueryPerformanceCounter(&last, NULL);
+    next.QuadPart = last.QuadPart + stream->period;
+
+    while(!stream->please_quit){
+        NtSetEvent(stream->event, NULL);
+        NtDelayExecution(FALSE, &delay);
+        NtQueryPerformanceCounter(&last, NULL);
+
+        adjust = next.QuadPart - last.QuadPart;
+        if(adjust > stream->period / 2)
+            adjust = stream->period / 2;
+        else if(adjust < -stream->period / 2)
+            adjust = -stream->period / 2;
+
+        delay.QuadPart = -(stream->period + adjust);
+        next.QuadPart += stream->period;
+    }
+}
+
 static NTSTATUS unix_start(void *args)
 {
     struct start_params *params = args;
     struct coreaudio_stream *stream = handle_get_stream(params->stream);
+    static const WCHAR name[] = {'a','u','d','i','o','_','c','l','i','e','n','t','_','t','i','m','e','r',0};
 
     os_unfair_lock_lock(&stream->lock);
 
@@ -1366,6 +1394,7 @@ static NTSTATUS unix_start(void *args)
     }
 
     os_unfair_lock_unlock(&stream->lock);
+    if (!stream->timer_thread) create_unix_thread( &stream->timer_thread, name, unix_timer_loop, stream );
 
     return STATUS_SUCCESS;
 }
@@ -1414,35 +1443,6 @@ static NTSTATUS unix_reset(void *args)
     }
 
     os_unfair_lock_unlock(&stream->lock);
-    return STATUS_SUCCESS;
-}
-
-static NTSTATUS unix_timer_loop(void *args)
-{
-    struct timer_loop_params *params = args;
-    struct coreaudio_stream *stream = handle_get_stream(params->stream);
-    LARGE_INTEGER delay, next, last;
-    int adjust;
-
-    delay.QuadPart = -stream->period;
-    NtQueryPerformanceCounter(&last, NULL);
-    next.QuadPart = last.QuadPart + stream->period;
-
-    while(!stream->please_quit){
-        NtSetEvent(stream->event, NULL);
-        NtDelayExecution(FALSE, &delay);
-        NtQueryPerformanceCounter(&last, NULL);
-
-        adjust = next.QuadPart - last.QuadPart;
-        if(adjust > stream->period / 2)
-            adjust = stream->period / 2;
-        else if(adjust < -stream->period / 2)
-            adjust = -stream->period / 2;
-
-        delay.QuadPart = -(stream->period + adjust);
-        next.QuadPart += stream->period;
-    }
-
     return STATUS_SUCCESS;
 }
 
@@ -1783,7 +1783,6 @@ const unixlib_entry_t __wine_unix_call_funcs[] =
     unix_start,
     unix_stop,
     unix_reset,
-    unix_timer_loop,
     unix_get_render_buffer,
     unix_release_render_buffer,
     unix_get_capture_buffer,
@@ -1883,13 +1882,11 @@ static NTSTATUS unix_wow64_release_stream(void *args)
     struct
     {
         stream_handle stream;
-        PTR32 timer_thread;
         HRESULT result;
     } *params32 = args;
     struct release_stream_params params =
     {
         .stream = params32->stream,
-        .timer_thread = ULongToHandle(params32->timer_thread)
     };
     unix_release_stream(&params);
     params32->result = params.result;
@@ -2227,7 +2224,6 @@ const unixlib_entry_t __wine_unix_call_wow64_funcs[] =
     unix_start,
     unix_stop,
     unix_reset,
-    unix_timer_loop,
     unix_wow64_get_render_buffer,
     unix_release_render_buffer,
     unix_wow64_get_capture_buffer,

--- a/dlls/winecrt0/unix_lib.c
+++ b/dlls/winecrt0/unix_lib.c
@@ -94,3 +94,22 @@ NTSTATUS WINAPI __wine_init_unix_call(void)
     return NtQueryVirtualMemory( GetCurrentProcess(), image_base(), MemoryWineLoadUnixLib,
                                  &__wine_unixlib_handle, sizeof(__wine_unixlib_handle), NULL );
 }
+
+NTSTATUS WINAPI __wine_load_unix_lib( const UNICODE_STRING *name, unixlib_module_t *lib,
+                                      unixlib_handle_t *handle )
+{
+    UINT64 res[2];
+    NTSTATUS status = NtQueryVirtualMemory( GetCurrentProcess(), name, MemoryWineLoadUnixLibByName,
+                                            res, handle ? sizeof(res) : sizeof(res[0]), NULL );
+    if (!status)
+    {
+        if (lib) *lib = res[0];
+        if (handle) *handle = res[1];
+    }
+    return status;
+}
+
+NTSTATUS WINAPI __wine_unload_unix_lib( unixlib_module_t lib )
+{
+    return NtQueryVirtualMemory( GetCurrentProcess(), &lib, MemoryWineUnloadUnixLib, NULL, 0, NULL );
+}

--- a/dlls/winecrt0/unix_lib.c
+++ b/dlls/winecrt0/unix_lib.c
@@ -91,6 +91,6 @@ NTSTATUS __attribute__((naked)) __wine_unix_call_arm64ec( unixlib_handle_t handl
 
 NTSTATUS WINAPI __wine_init_unix_call(void)
 {
-    return NtQueryVirtualMemory( GetCurrentProcess(), image_base(), MemoryWineUnixFuncs,
+    return NtQueryVirtualMemory( GetCurrentProcess(), image_base(), MemoryWineLoadUnixLib,
                                  &__wine_unixlib_handle, sizeof(__wine_unixlib_handle), NULL );
 }

--- a/dlls/wineoss.drv/Makefile.in
+++ b/dlls/wineoss.drv/Makefile.in
@@ -1,7 +1,4 @@
-MODULE    = wineoss.drv
 UNIXLIB   = wineoss.so
-IMPORTS   = uuid ole32 user32 advapi32
-DELAYIMPORTS = winmm
 UNIX_LIBS    = $(OSS4_LIBS) $(PTHREAD_LIBS)
 UNIX_CFLAGS  = $(OSS4_CFLAGS)
 

--- a/dlls/wineoss.drv/oss.c
+++ b/dlls/wineoss.drv/oss.c
@@ -237,13 +237,6 @@ static NTSTATUS oss_process_attach(void *args)
     return STATUS_SUCCESS;
 }
 
-static NTSTATUS oss_main_loop(void *args)
-{
-    struct main_loop_params *params = args;
-    NtSetEvent(params->event, NULL);
-    return STATUS_SUCCESS;
-}
-
 static NTSTATUS oss_get_endpoint_ids(void *args)
 {
     struct get_endpoint_ids_params *params = args;
@@ -1639,7 +1632,8 @@ const unixlib_entry_t __wine_unix_call_funcs[] =
 {
     oss_process_attach,
     oss_not_implemented,
-    oss_main_loop,
+    oss_not_implemented,
+    oss_not_implemented,
     oss_get_endpoint_ids,
     oss_create_stream,
     oss_release_stream,
@@ -1696,19 +1690,6 @@ static NTSTATUS oss_wow64_test_connect(void *args)
     oss_test_connect(&params);
     params32->priority = params.priority;
     return STATUS_SUCCESS;
-}
-
-static NTSTATUS oss_wow64_main_loop(void *args)
-{
-    struct
-    {
-        PTR32 event;
-    } *params32 = args;
-    struct main_loop_params params =
-    {
-        .event = ULongToHandle(params32->event)
-    };
-    return oss_main_loop(&params);
 }
 
 static NTSTATUS oss_wow64_get_endpoint_ids(void *args)
@@ -2135,7 +2116,8 @@ const unixlib_entry_t __wine_unix_call_wow64_funcs[] =
 {
     oss_process_attach,
     oss_not_implemented,
-    oss_wow64_main_loop,
+    oss_not_implemented,
+    oss_not_implemented,
     oss_wow64_get_endpoint_ids,
     oss_wow64_create_stream,
     oss_wow64_release_stream,

--- a/dlls/wineoss.drv/oss.c
+++ b/dlls/wineoss.drv/oss.c
@@ -52,6 +52,7 @@ struct oss_stream
     UINT flags;
     AUDCLNT_SHAREMODE share;
     HANDLE event;
+    HANDLE timer_thread;
 
     int fd;
 
@@ -630,10 +631,10 @@ static NTSTATUS oss_release_stream(void *args)
     struct oss_stream *stream = handle_get_stream(params->stream);
     SIZE_T size;
 
-    if(params->timer_thread){
+    if(stream->timer_thread){
         stream->please_quit = TRUE;
-        NtWaitForSingleObject(params->timer_thread, FALSE, NULL);
-        NtClose(params->timer_thread);
+        NtWaitForSingleObject(stream->timer_thread, FALSE, NULL);
+        NtClose(stream->timer_thread);
     }
 
     close(stream->fd);
@@ -651,66 +652,6 @@ static NTSTATUS oss_release_stream(void *args)
 
     params->result = S_OK;
     return STATUS_SUCCESS;
-}
-
-static NTSTATUS oss_start(void *args)
-{
-    struct start_params *params = args;
-    struct oss_stream *stream = handle_get_stream(params->stream);
-
-    oss_lock(stream);
-
-    if((stream->flags & AUDCLNT_STREAMFLAGS_EVENTCALLBACK) && !stream->event)
-        return oss_unlock_result(stream, &params->result, AUDCLNT_E_EVENTHANDLE_NOT_SET);
-
-    if(stream->playing)
-        return oss_unlock_result(stream, &params->result, AUDCLNT_E_NOT_STOPPED);
-
-    stream->playing = TRUE;
-
-    return oss_unlock_result(stream, &params->result, S_OK);
-}
-
-static NTSTATUS oss_stop(void *args)
-{
-    struct stop_params *params = args;
-    struct oss_stream *stream = handle_get_stream(params->stream);
-
-    oss_lock(stream);
-
-    if(!stream->playing)
-        return oss_unlock_result(stream, &params->result, S_FALSE);
-
-    stream->playing = FALSE;
-    stream->in_oss_frames = 0;
-
-    return oss_unlock_result(stream, &params->result, S_OK);
-}
-
-static NTSTATUS oss_reset(void *args)
-{
-    struct reset_params *params = args;
-    struct oss_stream *stream = handle_get_stream(params->stream);
-
-    oss_lock(stream);
-
-    if(stream->playing)
-        return oss_unlock_result(stream, &params->result, AUDCLNT_E_NOT_STOPPED);
-
-    if(stream->getbuf_last)
-        return oss_unlock_result(stream, &params->result, AUDCLNT_E_BUFFER_OPERATION_PENDING);
-
-    if(stream->flow == eRender){
-        stream->written_frames = 0;
-        stream->last_pos_frames = 0;
-    }else{
-        stream->written_frames += stream->held_frames;
-    }
-    stream->held_frames = 0;
-    stream->lcl_offs_frames = 0;
-    stream->in_oss_frames = 0;
-
-    return oss_unlock_result(stream, &params->result, S_OK);
 }
 
 static void silence_buffer(struct oss_stream *stream, BYTE *buffer, UINT32 frames)
@@ -860,10 +801,9 @@ static void oss_read_data(struct oss_stream *stream)
     }
 }
 
-static NTSTATUS oss_timer_loop(void *args)
+static void oss_timer_loop(void *args)
 {
-    struct timer_loop_params *params = args;
-    struct oss_stream *stream = handle_get_stream(params->stream);
+    struct oss_stream *stream = args;
     LARGE_INTEGER delay, now, next;
     int adjust;
 
@@ -898,8 +838,68 @@ static NTSTATUS oss_timer_loop(void *args)
     }
 
     oss_unlock(stream);
+}
 
-    return STATUS_SUCCESS;
+static NTSTATUS oss_start(void *args)
+{
+    struct start_params *params = args;
+    struct oss_stream *stream = handle_get_stream(params->stream);
+    static const WCHAR name[] = {'a','u','d','i','o','_','c','l','i','e','n','t','_','t','i','m','e','r',0};
+
+    oss_lock(stream);
+
+    if((stream->flags & AUDCLNT_STREAMFLAGS_EVENTCALLBACK) && !stream->event)
+        return oss_unlock_result(stream, &params->result, AUDCLNT_E_EVENTHANDLE_NOT_SET);
+
+    if(stream->playing)
+        return oss_unlock_result(stream, &params->result, AUDCLNT_E_NOT_STOPPED);
+
+    stream->playing = TRUE;
+    if (!stream->timer_thread) create_unix_thread( &stream->timer_thread, name, oss_timer_loop, stream );
+
+    return oss_unlock_result(stream, &params->result, S_OK);
+}
+
+static NTSTATUS oss_stop(void *args)
+{
+    struct stop_params *params = args;
+    struct oss_stream *stream = handle_get_stream(params->stream);
+
+    oss_lock(stream);
+
+    if(!stream->playing)
+        return oss_unlock_result(stream, &params->result, S_FALSE);
+
+    stream->playing = FALSE;
+    stream->in_oss_frames = 0;
+
+    return oss_unlock_result(stream, &params->result, S_OK);
+}
+
+static NTSTATUS oss_reset(void *args)
+{
+    struct reset_params *params = args;
+    struct oss_stream *stream = handle_get_stream(params->stream);
+
+    oss_lock(stream);
+
+    if(stream->playing)
+        return oss_unlock_result(stream, &params->result, AUDCLNT_E_NOT_STOPPED);
+
+    if(stream->getbuf_last)
+        return oss_unlock_result(stream, &params->result, AUDCLNT_E_BUFFER_OPERATION_PENDING);
+
+    if(stream->flow == eRender){
+        stream->written_frames = 0;
+        stream->last_pos_frames = 0;
+    }else{
+        stream->written_frames += stream->held_frames;
+    }
+    stream->held_frames = 0;
+    stream->lcl_offs_frames = 0;
+    stream->in_oss_frames = 0;
+
+    return oss_unlock_result(stream, &params->result, S_OK);
 }
 
 static NTSTATUS oss_get_render_buffer(void *args)
@@ -1640,7 +1640,6 @@ const unixlib_entry_t __wine_unix_call_funcs[] =
     oss_start,
     oss_stop,
     oss_reset,
-    oss_timer_loop,
     oss_get_render_buffer,
     oss_release_render_buffer,
     oss_get_capture_buffer,
@@ -1756,13 +1755,11 @@ static NTSTATUS oss_wow64_release_stream(void *args)
     struct
     {
         stream_handle stream;
-        PTR32 timer_thread;
         HRESULT result;
     } *params32 = args;
     struct release_stream_params params =
     {
         .stream = params32->stream,
-        .timer_thread = ULongToHandle(params32->timer_thread)
     };
     oss_release_stream(&params);
     params32->result = params.result;
@@ -2124,7 +2121,6 @@ const unixlib_entry_t __wine_unix_call_wow64_funcs[] =
     oss_start,
     oss_stop,
     oss_reset,
-    oss_timer_loop,
     oss_wow64_get_render_buffer,
     oss_release_render_buffer,
     oss_wow64_get_capture_buffer,

--- a/dlls/winepipewire.drv/Makefile.in
+++ b/dlls/winepipewire.drv/Makefile.in
@@ -1,0 +1,6 @@
+UNIXLIB   = winepipewire.so
+UNIX_LIBS    = $(PIPEWIRE_LIBS) $(PTHREAD_LIBS)
+UNIX_CFLAGS  = $(PIPEWIRE_CFLAGS)
+
+SOURCES = \
+	pipewire.c

--- a/dlls/winepipewire.drv/pipewire.c
+++ b/dlls/winepipewire.drv/pipewire.c
@@ -528,7 +528,14 @@ static NTSTATUS pipewire_main_loop_start(void *args)
         pw_loop_global = NULL;
         goto out;
     }
-    pw_thread_loop_start(pw_loop_global);
+    if (pw_thread_loop_start(pw_loop_global) < 0)
+    {
+        ERR("pw_thread_loop_start failed\n");
+        pw_context_destroy(pw_ctx);
+        pw_ctx = NULL;
+        pw_thread_loop_destroy(pw_loop_global);
+        pw_loop_global = NULL;
+    }
 
 out:
     pthread_mutex_unlock(&pw_init_mutex);
@@ -1545,6 +1552,12 @@ static NTSTATUS pipewire_create_stream(void *args)
     SIZE_T bufsize_bytes, size;
     UINT32 i;
     HRESULT hr;
+
+    if (!pw_loop_global)
+    {
+        params->result = AUDCLNT_E_ENDPOINT_CREATE_FAILED;
+        return STATUS_SUCCESS;
+    }
 
     if (params->share == AUDCLNT_SHAREMODE_EXCLUSIVE)
     {

--- a/dlls/winepipewire.drv/pipewire.c
+++ b/dlls/winepipewire.drv/pipewire.c
@@ -945,7 +945,6 @@ static NTSTATUS pipewire_test_connect(void *args)
     struct test_connect_params *params = args;
     struct probe p;
     struct probe_node *pn, *next;
-    char *name;
 
     free_device_lists();
     list_init(&g_render_devices);
@@ -1008,11 +1007,9 @@ static NTSTATUS pipewire_test_connect(void *args)
         free(pn);
     }
 
-    name = wstr_to_str(params->name);
     TRACE("probe for %s: %u sinks default=%s, %u sources default=%s, rate=%u\n",
-          debugstr_a(name), list_count(&g_render_devices), debugstr_a(g_default_sink),
+          debugstr_w(params->name), list_count(&g_render_devices), debugstr_a(g_default_sink),
           list_count(&g_capture_devices), debugstr_a(g_default_source), p.clock_rate);
-    free(name);
 
     params->priority = Priority_Preferred;
     return STATUS_SUCCESS;

--- a/dlls/winepipewire.drv/pipewire.c
+++ b/dlls/winepipewire.drv/pipewire.c
@@ -1845,29 +1845,37 @@ static void pipewire_period_timer_loop(void *args)
         }
         else
         {
-            INT32 adjust = period->last_time + period->period_usec - now;
+            INT64 adjust = (INT64)(period->last_time + period->period_usec) - (INT64)now;
 
-            if (adjust > (INT32)(period->period_usec / 2))
-                adjust = period->period_usec / 2;
-            else if (adjust < -(INT32)(period->period_usec / 2))
-                adjust = -(INT32)(period->period_usec / 2);
-
-            delay.QuadPart = -((INT64)period->period_usec + adjust) * 10;
-            period->last_time += period->period_usec;
-
-            LIST_FOR_EACH_ENTRY(stream, &period->streams, struct pipewire_stream, period_entry)
+            if (adjust > 1000000 || adjust < -1000000)
             {
-                if (!stream->started)
-                    continue;
-                if (stream->dataflow == eRender)
+                /* graph clock stalled or jumped: re-acquire the grid next tick */
+                period->grid_valid = FALSE;
+            }
+            else
+            {
+                if (adjust > (INT64)(period->period_usec / 2))
+                    adjust = period->period_usec / 2;
+                else if (adjust < -(INT64)(period->period_usec / 2))
+                    adjust = -(INT64)(period->period_usec / 2);
+
+                delay.QuadPart = -((INT64)period->period_usec + adjust) * 10;
+                period->last_time += period->period_usec;
+
+                LIST_FOR_EACH_ENTRY(stream, &period->streams, struct pipewire_stream, period_entry)
                 {
-                    UINT32 adv = min(stream->period_bytes, stream->held_bytes);
-                    stream->lcl_offs_bytes += adv;
-                    stream->lcl_offs_bytes %= stream->real_bufsize_bytes;
-                    stream->held_bytes -= adv;
+                    if (!stream->started)
+                        continue;
+                    if (stream->dataflow == eRender)
+                    {
+                        UINT32 adv = min(stream->period_bytes, stream->held_bytes);
+                        stream->lcl_offs_bytes += adv;
+                        stream->lcl_offs_bytes %= stream->real_bufsize_bytes;
+                        stream->held_bytes -= adv;
+                    }
+                    else
+                        pipewire_read(stream);
                 }
-                else
-                    pipewire_read(stream);
             }
         }
 

--- a/dlls/winepipewire.drv/pipewire.c
+++ b/dlls/winepipewire.drv/pipewire.c
@@ -1418,8 +1418,9 @@ static void on_stream_process(void *data)
     {
         if (stream->started && stream->capture_ring)
         {
-            UINT32 avail = d->chunk->size;
-            const BYTE *src = (const BYTE *)d->data + d->chunk->offset;
+            UINT32 offs = min(d->chunk->offset, d->maxsize);
+            UINT32 avail = min(d->chunk->size, d->maxsize - offs);
+            const BYTE *src = (const BYTE *)d->data + offs;
             SIZE_T n = avail;
 
             if (n > stream->capture_ring_size)

--- a/dlls/winepipewire.drv/pipewire.c
+++ b/dlls/winepipewire.drv/pipewire.c
@@ -718,6 +718,13 @@ static void on_probe_registry_global(void *data, uint32_t id, uint32_t permissio
         pn->flow = !strcmp(media_class, "Audio/Sink") ? eRender : eCapture;
         pn->node_name = strdup(node_name);
         pn->display = strdup(desc ? desc : (nick ? nick : node_name));
+        if (!pn->node_name || !pn->display)
+        {
+            free(pn->node_name);
+            free(pn->display);
+            free(pn);
+            return;
+        }
         list_add_tail(&p->nodes, &pn->entry);
 
         /* Bind the node and ask for its supported formats so we can report
@@ -812,22 +819,28 @@ static void build_device_cache(struct probe *p)
     }
     if ((def = malloc(offsetof(struct pw_phys_device, pw_name) + 1)))
     {
-        def->pw_name[0] = '\0';
-        def->display = utf8_to_wstr("PipeWire");
-        def->form = Speakers;
-        def->def_period = 100000;
-        def->min_period = 30000;
-        if (def_src)
+        if (!(def->display = utf8_to_wstr("PipeWire")))
         {
-            def->fmt = def_src->fmt;
-            def->channel_mask = def_src->channel_mask;
+            free(def);
         }
         else
         {
-            build_format(&def->fmt, rate, 2, SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT);
-            def->channel_mask = def->fmt.dwChannelMask;
+            def->pw_name[0] = '\0';
+            def->form = Speakers;
+            def->def_period = 100000;
+            def->min_period = 30000;
+            if (def_src)
+            {
+                def->fmt = def_src->fmt;
+                def->channel_mask = def_src->channel_mask;
+            }
+            else
+            {
+                build_format(&def->fmt, rate, 2, SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT);
+                def->channel_mask = def->fmt.dwChannelMask;
+            }
+            list_add_head(&g_render_devices, &def->entry);
         }
-        list_add_head(&g_render_devices, &def->entry);
     }
 
     def_src = NULL;
@@ -838,22 +851,28 @@ static void build_device_cache(struct probe *p)
     }
     if ((def = malloc(offsetof(struct pw_phys_device, pw_name) + 1)))
     {
-        def->pw_name[0] = '\0';
-        def->display = utf8_to_wstr("PipeWire");
-        def->form = Microphone;
-        def->def_period = 100000;
-        def->min_period = 30000;
-        if (def_src)
+        if (!(def->display = utf8_to_wstr("PipeWire")))
         {
-            def->fmt = def_src->fmt;
-            def->channel_mask = def_src->channel_mask;
+            free(def);
         }
         else
         {
-            build_format(&def->fmt, rate, 2, SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT);
-            def->channel_mask = def->fmt.dwChannelMask;
+            def->pw_name[0] = '\0';
+            def->form = Microphone;
+            def->def_period = 100000;
+            def->min_period = 30000;
+            if (def_src)
+            {
+                def->fmt = def_src->fmt;
+                def->channel_mask = def_src->channel_mask;
+            }
+            else
+            {
+                build_format(&def->fmt, rate, 2, SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT);
+                def->channel_mask = def->fmt.dwChannelMask;
+            }
+            list_add_head(&g_capture_devices, &def->entry);
         }
-        list_add_head(&g_capture_devices, &def->entry);
     }
 }
 

--- a/dlls/winepipewire.drv/pipewire.c
+++ b/dlls/winepipewire.drv/pipewire.c
@@ -2600,6 +2600,16 @@ static NTSTATUS pipewire_set_sample_rate(void *args)
         goto exit;
     }
 
+    /* PulseAudio rejects rates outside [1, 48000 * 8] in
+     * pa_stream_update_sample_rate; mirror winepulse's observable failure
+     * code for rates the resampler cannot honor (the negated comparison
+     * also catches NaN). */
+    if (!(params->rate >= 1.0f && params->rate <= 384000.0f))
+    {
+        hr = E_OUTOFMEMORY;
+        goto exit;
+    }
+
     ratio = params->rate / (float)stream->rate_connected;
     if (pw_stream_set_control(stream->pw, SPA_PROP_rate, 1, &ratio, 0) < 0)
     {

--- a/dlls/winepipewire.drv/pipewire.c
+++ b/dlls/winepipewire.drv/pipewire.c
@@ -44,6 +44,7 @@
 #include <spa/utils/json.h>
 
 #include "ntstatus.h"
+#define WIN32_NO_STATUS
 #include "winternl.h"
 
 #include "mmdeviceapi.h"

--- a/dlls/winepipewire.drv/pipewire.c
+++ b/dlls/winepipewire.drv/pipewire.c
@@ -449,8 +449,14 @@ static NTSTATUS pipewire_process_attach(void *args)
 
 static NTSTATUS pipewire_process_detach(void *args)
 {
+    /* May run at process exit (DLL_PROCESS_DETACH with lpvReserved set), with
+     * the pw_thread_loop still running: it is a raw pthread that process
+     * termination does not stop, and main_loop_stop is skipped on that path.
+     * Do not take the loop lock (a killed thread may have held it) and do not
+     * pw_deinit() here (it dlcloses the PipeWire modules under the live loop
+     * thread).  Clean library teardown happens in pipewire_main_loop_stop on
+     * the FreeLibrary path; at process exit the OS reclaims everything. */
     free_device_lists();
-    pw_deinit();
     return STATUS_SUCCESS;
 }
 
@@ -554,6 +560,7 @@ static NTSTATUS pipewire_main_loop_stop(void *args)
         pw_loop_global = NULL;
     }
     pthread_mutex_unlock(&pw_init_mutex);
+    pw_deinit();
     return STATUS_SUCCESS;
 }
 

--- a/dlls/winepipewire.drv/pipewire.c
+++ b/dlls/winepipewire.drv/pipewire.c
@@ -60,6 +60,10 @@ WINE_DEFAULT_DEBUG_CHANNEL(pipewire);
 
 #define PW_CHANNELS_MAX 64
 
+/* Constrains driver allocations to the 32-bit address space for WoW64
+ * callers; left 0 for native 64-bit processes. */
+static ULONG_PTR zero_bits = 0;
+
 /* ----------------------------------------------------------------------
  * Stream and device structures (struct pulse_stream transplant)
  * ---------------------------------------------------------------------- */
@@ -1581,7 +1585,7 @@ static NTSTATUS pipewire_create_stream(void *args)
     {
         size = stream->real_bufsize_bytes = stream->bufsize_frames * 2 * stream->frame_size;
         if (NtAllocateVirtualMemory(GetCurrentProcess(), (void **)&stream->local_buffer,
-                                    0, &size, MEM_COMMIT, PAGE_READWRITE))
+                                    zero_bits, &size, MEM_COMMIT, PAGE_READWRITE))
             hr = E_OUTOFMEMORY;
     }
     else
@@ -1596,7 +1600,7 @@ static NTSTATUS pipewire_create_stream(void *args)
 
         size = stream->real_bufsize_bytes + capture_packets * sizeof(ACPacket);
         if (NtAllocateVirtualMemory(GetCurrentProcess(), (void **)&stream->local_buffer,
-                                    0, &size, MEM_COMMIT, PAGE_READWRITE))
+                                    zero_bits, &size, MEM_COMMIT, PAGE_READWRITE))
             hr = E_OUTOFMEMORY;
         else
         {
@@ -1615,7 +1619,7 @@ static NTSTATUS pipewire_create_stream(void *args)
             /* staging ring fed by the process callback */
             size = stream->capture_ring_size = stream->real_bufsize_bytes;
             if (NtAllocateVirtualMemory(GetCurrentProcess(), (void **)&stream->capture_ring,
-                                        0, &size, MEM_COMMIT, PAGE_READWRITE))
+                                        zero_bits, &size, MEM_COMMIT, PAGE_READWRITE))
                 hr = E_OUTOFMEMORY;
         }
     }
@@ -1959,7 +1963,7 @@ static BOOL alloc_tmp_buffer(struct pipewire_stream *stream, SIZE_T bytes)
         stream->tmp_buffer_bytes = 0;
     }
     if (NtAllocateVirtualMemory(GetCurrentProcess(), (void **)&stream->tmp_buffer,
-                                0, &bytes, MEM_COMMIT, PAGE_READWRITE))
+                                zero_bits, &bytes, MEM_COMMIT, PAGE_READWRITE))
         return FALSE;
 
     stream->tmp_buffer_bytes = bytes;
@@ -2508,55 +2512,492 @@ C_ASSERT(ARRAYSIZE(__wine_unix_call_funcs) == funcs_count);
 
 #ifdef _WIN64
 
-/* 32-bit (WoW64) processes are not supported yet.  Returning a failure status
- * makes mmdevapi's load_driver skip this driver, so those processes fall back
- * to the next entry in the driver list (e.g. pulse).  load_driver inspects this
- * status directly via the raw __wine_unix_call, so the asserting wine_unix_call
- * wrapper is never reached for an unloaded driver. */
-static NTSTATUS pipewire_wow64_not_supported(void *args)
+typedef UINT PTR32;
+
+static NTSTATUS pipewire_wow64_process_attach(void *args)
 {
-    return STATUS_NOT_IMPLEMENTED;
+    SYSTEM_BASIC_INFORMATION info;
+
+    NtQuerySystemInformation(SystemEmulationBasicInformation, &info, sizeof(info), NULL);
+    zero_bits = (ULONG_PTR)info.HighestUserAddress | 0x7fffffff;
+
+    return pipewire_process_attach( args );
+}
+
+static NTSTATUS pipewire_wow64_get_endpoint_ids(void *args)
+{
+    struct
+    {
+        EDataFlow flow;
+        PTR32 endpoints;
+        unsigned int size;
+        HRESULT result;
+        unsigned int num;
+        unsigned int default_idx;
+    } *params32 = args;
+    struct get_endpoint_ids_params params =
+    {
+        .flow = params32->flow,
+        .endpoints = ULongToPtr(params32->endpoints),
+        .size = params32->size
+    };
+    pipewire_get_endpoint_ids(&params);
+    params32->size = params.size;
+    params32->result = params.result;
+    params32->num = params.num;
+    params32->default_idx = params.default_idx;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_wow64_create_stream(void *args)
+{
+    struct
+    {
+        PTR32 name;
+        PTR32 device;
+        EDataFlow flow;
+        AUDCLNT_SHAREMODE share;
+        DWORD flags;
+        REFERENCE_TIME duration;
+        REFERENCE_TIME period;
+        PTR32 fmt;
+        HRESULT result;
+        PTR32 channel_count;
+        PTR32 stream;
+    } *params32 = args;
+    struct create_stream_params params =
+    {
+        .name = ULongToPtr(params32->name),
+        .device = ULongToPtr(params32->device),
+        .flow = params32->flow,
+        .share = params32->share,
+        .flags = params32->flags,
+        .duration = params32->duration,
+        .period = params32->period,
+        .fmt = ULongToPtr(params32->fmt),
+        .channel_count = ULongToPtr(params32->channel_count),
+        .stream = ULongToPtr(params32->stream)
+    };
+    pipewire_create_stream(&params);
+    params32->result = params.result;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_wow64_release_stream(void *args)
+{
+    struct
+    {
+        stream_handle stream;
+        HRESULT result;
+    } *params32 = args;
+    struct release_stream_params params =
+    {
+        .stream = params32->stream,
+    };
+    pipewire_release_stream(&params);
+    params32->result = params.result;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_wow64_get_render_buffer(void *args)
+{
+    struct
+    {
+        stream_handle stream;
+        UINT32 frames;
+        HRESULT result;
+        PTR32 data;
+    } *params32 = args;
+    BYTE *data = NULL;
+    struct get_render_buffer_params params =
+    {
+        .stream = params32->stream,
+        .frames = params32->frames,
+        .data = &data
+    };
+    pipewire_get_render_buffer(&params);
+    params32->result = params.result;
+    *(unsigned int *)ULongToPtr(params32->data) = PtrToUlong(data);
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_wow64_get_capture_buffer(void *args)
+{
+    struct
+    {
+        stream_handle stream;
+        HRESULT result;
+        PTR32 data;
+        PTR32 frames;
+        PTR32 flags;
+        PTR32 devpos;
+        PTR32 qpcpos;
+    } *params32 = args;
+    BYTE *data = NULL;
+    struct get_capture_buffer_params params =
+    {
+        .stream = params32->stream,
+        .data = &data,
+        .frames = ULongToPtr(params32->frames),
+        .flags = ULongToPtr(params32->flags),
+        .devpos = ULongToPtr(params32->devpos),
+        .qpcpos = ULongToPtr(params32->qpcpos)
+    };
+    pipewire_get_capture_buffer(&params);
+    params32->result = params.result;
+    *(unsigned int *)ULongToPtr(params32->data) = PtrToUlong(data);
+    return STATUS_SUCCESS;
+};
+
+static NTSTATUS pipewire_wow64_is_format_supported(void *args)
+{
+    struct
+    {
+        PTR32 device;
+        EDataFlow flow;
+        AUDCLNT_SHAREMODE share;
+        PTR32 fmt_in;
+        HRESULT result;
+    } *params32 = args;
+    struct is_format_supported_params params =
+    {
+        .device = ULongToPtr(params32->device),
+        .flow = params32->flow,
+        .share = params32->share,
+        .fmt_in = ULongToPtr(params32->fmt_in),
+    };
+    pipewire_is_format_supported(&params);
+    params32->result = params.result;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_wow64_get_loopback_capture_device(void *args)
+{
+    struct
+    {
+        PTR32 name;
+        PTR32 device;
+        PTR32 ret_device;
+        UINT32 ret_device_len;
+        HRESULT result;
+    } *params32 = args;
+
+    struct get_loopback_capture_device_params params =
+    {
+        .name = ULongToPtr(params32->name),
+        .device = ULongToPtr(params32->device),
+        .ret_device = ULongToPtr(params32->ret_device),
+        .ret_device_len = params32->ret_device_len,
+    };
+
+    pipewire_get_loopback_capture_device(&params);
+    params32->result = params.result;
+    params32->ret_device_len = params.ret_device_len;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_wow64_get_mix_format(void *args)
+{
+    struct
+    {
+        PTR32 device;
+        EDataFlow flow;
+        PTR32 fmt;
+        HRESULT result;
+    } *params32 = args;
+    struct get_mix_format_params params =
+    {
+        .device = ULongToPtr(params32->device),
+        .flow = params32->flow,
+        .fmt = ULongToPtr(params32->fmt),
+    };
+    pipewire_get_mix_format(&params);
+    params32->result = params.result;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_wow64_get_device_period(void *args)
+{
+    struct
+    {
+        PTR32 device;
+        EDataFlow flow;
+        HRESULT result;
+        PTR32 def_period;
+        PTR32 min_period;
+    } *params32 = args;
+    struct get_device_period_params params =
+    {
+        .device = ULongToPtr(params32->device),
+        .flow = params32->flow,
+        .def_period = ULongToPtr(params32->def_period),
+        .min_period = ULongToPtr(params32->min_period),
+    };
+    pipewire_get_device_period(&params);
+    params32->result = params.result;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_wow64_get_buffer_size(void *args)
+{
+    struct
+    {
+        stream_handle stream;
+        HRESULT result;
+        PTR32 frames;
+    } *params32 = args;
+    struct get_buffer_size_params params =
+    {
+        .stream = params32->stream,
+        .frames = ULongToPtr(params32->frames)
+    };
+    pipewire_get_buffer_size(&params);
+    params32->result = params.result;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_wow64_get_latency(void *args)
+{
+    struct
+    {
+        stream_handle stream;
+        HRESULT result;
+        PTR32 latency;
+    } *params32 = args;
+    struct get_latency_params params =
+    {
+        .stream = params32->stream,
+        .latency = ULongToPtr(params32->latency)
+    };
+    pipewire_get_latency(&params);
+    params32->result = params.result;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_wow64_get_current_padding(void *args)
+{
+    struct
+    {
+        stream_handle stream;
+        HRESULT result;
+        PTR32 padding;
+    } *params32 = args;
+    struct get_current_padding_params params =
+    {
+        .stream = params32->stream,
+        .padding = ULongToPtr(params32->padding)
+    };
+    pipewire_get_current_padding(&params);
+    params32->result = params.result;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_wow64_get_next_packet_size(void *args)
+{
+    struct
+    {
+        stream_handle stream;
+        HRESULT result;
+        PTR32 frames;
+    } *params32 = args;
+    struct get_next_packet_size_params params =
+    {
+        .stream = params32->stream,
+        .frames = ULongToPtr(params32->frames)
+    };
+    pipewire_get_next_packet_size(&params);
+    params32->result = params.result;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_wow64_get_frequency(void *args)
+{
+    struct
+    {
+        stream_handle stream;
+        HRESULT result;
+        PTR32 freq;
+    } *params32 = args;
+    struct get_frequency_params params =
+    {
+        .stream = params32->stream,
+        .freq = ULongToPtr(params32->freq)
+    };
+    pipewire_get_frequency(&params);
+    params32->result = params.result;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_wow64_get_position(void *args)
+{
+    struct
+    {
+        stream_handle stream;
+        BOOL device;
+        HRESULT result;
+        PTR32 pos;
+        PTR32 qpctime;
+    } *params32 = args;
+    struct get_position_params params =
+    {
+        .stream = params32->stream,
+        .device = params32->device,
+        .pos = ULongToPtr(params32->pos),
+        .qpctime = ULongToPtr(params32->qpctime)
+    };
+    pipewire_get_position(&params);
+    params32->result = params.result;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_wow64_set_volumes(void *args)
+{
+    struct
+    {
+        stream_handle stream;
+        float master_volume;
+        PTR32 volumes;
+        PTR32 session_volumes;
+    } *params32 = args;
+    struct set_volumes_params params =
+    {
+        .stream = params32->stream,
+        .master_volume = params32->master_volume,
+        .volumes = ULongToPtr(params32->volumes),
+        .session_volumes = ULongToPtr(params32->session_volumes),
+    };
+    return pipewire_set_volumes(&params);
+}
+
+static NTSTATUS pipewire_wow64_set_event_handle(void *args)
+{
+    struct
+    {
+        stream_handle stream;
+        PTR32 event;
+        HRESULT result;
+    } *params32 = args;
+    struct set_event_handle_params params =
+    {
+        .stream = params32->stream,
+        .event = ULongToHandle(params32->event)
+    };
+    pipewire_set_event_handle(&params);
+    params32->result = params.result;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_wow64_test_connect(void *args)
+{
+    struct
+    {
+        PTR32 name;
+        enum driver_priority priority;
+    } *params32 = args;
+    struct test_connect_params params =
+    {
+        .name = ULongToPtr(params32->name),
+    };
+    pipewire_test_connect(&params);
+    params32->priority = params.priority;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_wow64_get_prop_value(void *args)
+{
+    struct propvariant32
+    {
+        WORD vt;
+        WORD pad1, pad2, pad3;
+        union
+        {
+            ULONG ulVal;
+            PTR32 ptr;
+            ULARGE_INTEGER uhVal;
+        };
+    } *value32;
+    struct
+    {
+        PTR32 device;
+        EDataFlow flow;
+        PTR32 guid;
+        PTR32 prop;
+        HRESULT result;
+        PTR32 value;
+        PTR32 buffer; /* caller allocated buffer to hold value's strings */
+        PTR32 buffer_size;
+    } *params32 = args;
+    PROPVARIANT value;
+    struct get_prop_value_params params =
+    {
+        .device = ULongToPtr(params32->device),
+        .flow = params32->flow,
+        .guid = ULongToPtr(params32->guid),
+        .prop = ULongToPtr(params32->prop),
+        .value = &value,
+        .buffer = ULongToPtr(params32->buffer),
+        .buffer_size = ULongToPtr(params32->buffer_size)
+    };
+    pipewire_get_prop_value(&params);
+    params32->result = params.result;
+    if (SUCCEEDED(params.result))
+    {
+        value32 = UlongToPtr(params32->value);
+        value32->vt = value.vt;
+        switch (value.vt)
+        {
+        case VT_UI4:
+            value32->ulVal = value.ulVal;
+            break;
+        case VT_LPWSTR:
+            value32->ptr = params32->buffer;
+            break;
+        default:
+            FIXME("Unhandled vt %04x\n", value.vt);
+        }
+    }
+    return STATUS_SUCCESS;
 }
 
 const unixlib_entry_t __wine_unix_call_wow64_funcs[] =
 {
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
-    pipewire_wow64_not_supported,
+    pipewire_wow64_process_attach,
+    pipewire_process_detach,
+    pipewire_main_loop_start,
+    pipewire_main_loop_stop,
+    pipewire_wow64_get_endpoint_ids,
+    pipewire_wow64_create_stream,
+    pipewire_wow64_release_stream,
+    pipewire_start,
+    pipewire_stop,
+    pipewire_reset,
+    pipewire_wow64_get_render_buffer,
+    pipewire_release_render_buffer,
+    pipewire_wow64_get_capture_buffer,
+    pipewire_release_capture_buffer,
+    pipewire_wow64_is_format_supported,
+    pipewire_wow64_get_loopback_capture_device,
+    pipewire_wow64_get_mix_format,
+    pipewire_wow64_get_device_period,
+    pipewire_wow64_get_buffer_size,
+    pipewire_wow64_get_latency,
+    pipewire_wow64_get_current_padding,
+    pipewire_wow64_get_next_packet_size,
+    pipewire_wow64_get_frequency,
+    pipewire_wow64_get_position,
+    pipewire_wow64_set_volumes,
+    pipewire_wow64_set_event_handle,
+    pipewire_set_sample_rate,
+    pipewire_wow64_test_connect,
+    pipewire_is_started,
+    pipewire_wow64_get_prop_value,
+    pipewire_midi_get_driver,
+    pipewire_not_implemented,
+    pipewire_not_implemented,
+    pipewire_not_implemented,
+    pipewire_not_implemented,
+    pipewire_not_implemented,
+    pipewire_not_implemented,
 };
 
 C_ASSERT(ARRAYSIZE(__wine_unix_call_wow64_funcs) == funcs_count);

--- a/dlls/winepipewire.drv/pipewire.c
+++ b/dlls/winepipewire.drv/pipewire.c
@@ -423,7 +423,8 @@ static void build_format(WAVEFORMATEXTENSIBLE *fmt, uint32_t rate, uint32_t chan
 }
 
 static struct pw_phys_device *add_device(struct list *list, const char *pw_name, const char *display,
-                                         EndpointFormFactor form, uint32_t rate, uint32_t channels, UINT mask)
+                                         EndpointFormFactor form, uint32_t rate, uint32_t channels, UINT mask,
+                                         REFERENCE_TIME min_period)
 {
     size_t len = strlen(pw_name);
     struct pw_phys_device *dev = malloc(offsetof(struct pw_phys_device, pw_name) + len + 1);
@@ -439,7 +440,7 @@ static struct pw_phys_device *add_device(struct list *list, const char *pw_name,
     build_format(&dev->fmt, rate, channels, mask);
     dev->channel_mask = dev->fmt.dwChannelMask;
     dev->def_period = 100000;
-    dev->min_period = 30000;
+    dev->min_period = min_period;
     memcpy(dev->pw_name, pw_name, len + 1);
     list_add_tail(list, &dev->entry);
     TRACE("%s (%s) channels=%u mask=%#x\n", debugstr_w(dev->display), pw_name,
@@ -638,6 +639,7 @@ struct probe
     char default_sink[256];
     char default_source[256];
     uint32_t clock_rate;
+    uint32_t min_quantum;
 };
 
 static void on_probe_node_param(void *data, int seq, uint32_t id, uint32_t index,
@@ -706,6 +708,16 @@ static int on_probe_settings_property(void *data, uint32_t subject, const char *
     else if (!strcmp(key, "clock.rate") && !p->clock_rate)
     {
         p->clock_rate = (uint32_t)strtoul(value, NULL, 10);
+    }
+    else if (!strcmp(key, "clock.force-quantum"))
+    {
+        uint32_t q = (uint32_t)strtoul(value, NULL, 10);
+        if (q)
+            p->min_quantum = q;
+    }
+    else if (!strcmp(key, "clock.min-quantum") && !p->min_quantum)
+    {
+        p->min_quantum = (uint32_t)strtoul(value, NULL, 10);
     }
     return 0;
 }
@@ -820,6 +832,25 @@ static void build_device_cache(struct probe *p)
     struct probe_node *pn;
     struct pw_phys_device *dev, *def_src, *def;
     uint32_t rate = p->clock_rate ? p->clock_rate : 48000;
+    REFERENCE_TIME min_period = 30000;
+
+    /* IAudioClient3 shared-mode floor.  The graph cannot deliver cycles
+     * below clock.min-quantum (clock.force-quantum pins it outright), and
+     * 128 frames (~2.7 ms at 48 kHz) matches the typical Windows engine
+     * floor.  Clamp to the 3 ms winepulse-parity value so the advertised
+     * minimum only ever improves; without settings metadata keep 3 ms. */
+    if (p->min_quantum)
+    {
+        /* Floor division: mmdevapi converts back with a ceiling, so this
+         * round-trips to the exact frame count. */
+        REFERENCE_TIME q = (REFERENCE_TIME)p->min_quantum * 10000000 / rate;
+        REFERENCE_TIME floor_rt = (REFERENCE_TIME)128 * 10000000 / rate;
+        min_period = q > floor_rt ? q : floor_rt;
+        if (min_period > 30000)
+            min_period = 30000;
+        TRACE("min_quantum=%u rate=%u -> min_period=%d hns\n",
+              p->min_quantum, rate, (int)min_period);
+    }
 
     lstrcpynA(g_default_sink, p->default_sink, sizeof(g_default_sink));
     lstrcpynA(g_default_source, p->default_source, sizeof(g_default_source));
@@ -831,7 +862,7 @@ static void build_device_cache(struct probe *p)
         uint32_t channels = pn->have_format ? pn->channels : 2;
         UINT mask = pn->have_format ? positions_to_mask(pn->position, pn->channels)
                                     : (SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT);
-        add_device(list, pn->node_name, pn->display, form, rate, channels, mask);
+        add_device(list, pn->node_name, pn->display, form, rate, channels, mask, min_period);
     }
 
     /* Synthetic default render device at index 0 (empty pw_name -> session
@@ -853,7 +884,7 @@ static void build_device_cache(struct probe *p)
             def->pw_name[0] = '\0';
             def->form = Speakers;
             def->def_period = 100000;
-            def->min_period = 30000;
+            def->min_period = min_period;
             if (def_src)
             {
                 def->fmt = def_src->fmt;
@@ -885,7 +916,7 @@ static void build_device_cache(struct probe *p)
             def->pw_name[0] = '\0';
             def->form = Microphone;
             def->def_period = 100000;
-            def->min_period = 30000;
+            def->min_period = min_period;
             if (def_src)
             {
                 def->fmt = def_src->fmt;

--- a/dlls/winepipewire.drv/pipewire.c
+++ b/dlls/winepipewire.drv/pipewire.c
@@ -91,6 +91,9 @@ struct pipewire_stream
     INT32 locked;
     BOOL started;
     SIZE_T bufsize_frames, real_bufsize_bytes, period_bytes;
+    /* render ring bookkeeping: lcl_offs/held track the application side,
+     * pa_offs/pa_held track the process-callback reader (field names kept
+     * from the pulse.c transplant for diffability). */
     SIZE_T lcl_offs_bytes, pa_offs_bytes;
     SIZE_T tmp_buffer_bytes, held_bytes, pa_held_bytes;
     BYTE *local_buffer, *tmp_buffer;
@@ -827,10 +830,46 @@ static void probe_roundtrip(struct probe *p)
     pw_thread_loop_timed_wait(p->loop, 2);
 }
 
+/* Synthetic default endpoint at index 0 (empty pw_name -> session manager
+ * default routing).  When the default node is known, mirror its format so
+ * the default endpoint advertises the real speaker layout. */
+static void add_default_device(struct list *list, EndpointFormFactor form, const char *match,
+                               uint32_t rate, REFERENCE_TIME min_period)
+{
+    struct pw_phys_device *dev, *def_src = NULL, *def;
+
+    if (match[0])
+    {
+        LIST_FOR_EACH_ENTRY(dev, list, struct pw_phys_device, entry)
+            if (!strcmp(dev->pw_name, match)) { def_src = dev; break; }
+    }
+    if (!(def = malloc(offsetof(struct pw_phys_device, pw_name) + 1)))
+        return;
+    if (!(def->display = utf8_to_wstr("PipeWire")))
+    {
+        free(def);
+        return;
+    }
+    def->pw_name[0] = '\0';
+    def->form = form;
+    def->def_period = 100000;
+    def->min_period = min_period;
+    if (def_src)
+    {
+        def->fmt = def_src->fmt;
+        def->channel_mask = def_src->channel_mask;
+    }
+    else
+    {
+        build_format(&def->fmt, rate, 2, SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT);
+        def->channel_mask = def->fmt.dwChannelMask;
+    }
+    list_add_head(list, &def->entry);
+}
+
 static void build_device_cache(struct probe *p)
 {
     struct probe_node *pn;
-    struct pw_phys_device *dev, *def_src, *def;
     uint32_t rate = p->clock_rate ? p->clock_rate : 48000;
     REFERENCE_TIME min_period = 30000;
 
@@ -865,71 +904,8 @@ static void build_device_cache(struct probe *p)
         add_device(list, pn->node_name, pn->display, form, rate, channels, mask, min_period);
     }
 
-    /* Synthetic default render device at index 0 (empty pw_name -> session
-     * manager default routing). */
-    def_src = NULL;
-    if (g_default_sink[0])
-    {
-        LIST_FOR_EACH_ENTRY(dev, &g_render_devices, struct pw_phys_device, entry)
-            if (!strcmp(dev->pw_name, g_default_sink)) { def_src = dev; break; }
-    }
-    if ((def = malloc(offsetof(struct pw_phys_device, pw_name) + 1)))
-    {
-        if (!(def->display = utf8_to_wstr("PipeWire")))
-        {
-            free(def);
-        }
-        else
-        {
-            def->pw_name[0] = '\0';
-            def->form = Speakers;
-            def->def_period = 100000;
-            def->min_period = min_period;
-            if (def_src)
-            {
-                def->fmt = def_src->fmt;
-                def->channel_mask = def_src->channel_mask;
-            }
-            else
-            {
-                build_format(&def->fmt, rate, 2, SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT);
-                def->channel_mask = def->fmt.dwChannelMask;
-            }
-            list_add_head(&g_render_devices, &def->entry);
-        }
-    }
-
-    def_src = NULL;
-    if (g_default_source[0])
-    {
-        LIST_FOR_EACH_ENTRY(dev, &g_capture_devices, struct pw_phys_device, entry)
-            if (!strcmp(dev->pw_name, g_default_source)) { def_src = dev; break; }
-    }
-    if ((def = malloc(offsetof(struct pw_phys_device, pw_name) + 1)))
-    {
-        if (!(def->display = utf8_to_wstr("PipeWire")))
-        {
-            free(def);
-        }
-        else
-        {
-            def->pw_name[0] = '\0';
-            def->form = Microphone;
-            def->def_period = 100000;
-            def->min_period = min_period;
-            if (def_src)
-            {
-                def->fmt = def_src->fmt;
-                def->channel_mask = def_src->channel_mask;
-            }
-            else
-            {
-                build_format(&def->fmt, rate, 2, SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT);
-                def->channel_mask = def->fmt.dwChannelMask;
-            }
-            list_add_head(&g_capture_devices, &def->entry);
-        }
-    }
+    add_default_device(&g_render_devices, Speakers, g_default_sink, rate, min_period);
+    add_default_device(&g_capture_devices, Microphone, g_default_source, rate, min_period);
 }
 
 static void probe_teardown(struct probe *p)

--- a/dlls/winepipewire.drv/pipewire.c
+++ b/dlls/winepipewire.drv/pipewire.c
@@ -2073,7 +2073,13 @@ static NTSTATUS pipewire_start(void *args)
         return STATUS_SUCCESS;
     }
 
-    pw_stream_set_active(stream->pw, true);
+    if (pw_stream_set_active(stream->pw, true) < 0)
+    {
+        /* mirrors pulse_start's failed-uncork path */
+        params->result = E_FAIL;
+        pw_thread_loop_unlock(pw_loop_global);
+        return STATUS_SUCCESS;
+    }
     stream->started = TRUE;
     pw_thread_loop_unlock(pw_loop_global);
     return STATUS_SUCCESS;

--- a/dlls/winepipewire.drv/pipewire.c
+++ b/dlls/winepipewire.drv/pipewire.c
@@ -80,7 +80,6 @@ struct pipewire_stream
     DWORD flags;
     AUDCLNT_SHAREMODE share;
     HANDLE event;
-    HANDLE timer_thread;
     float vol[PW_CHANNELS_MAX];
 
     REFERENCE_TIME def_period;
@@ -93,7 +92,6 @@ struct pipewire_stream
     SIZE_T tmp_buffer_bytes, held_bytes, pa_held_bytes;
     BYTE *local_buffer, *tmp_buffer;
     void *locked_ptr;
-    BOOL please_quit, just_started, just_underran;
     UINT64 mmdev_period_usec;
 
     /* capture staging ring: the analogue of PulseAudio's internal record
@@ -107,6 +105,10 @@ struct pipewire_stream
 
     struct list packet_free_head;
     struct list packet_filled_head;
+
+    char *device;
+    struct list period_entry;
+    struct pipewire_period *period;
 };
 
 typedef struct _ACPacket
@@ -128,6 +130,19 @@ struct pw_phys_device
     char pw_name[];
 };
 
+struct pipewire_period
+{
+    struct list entry;
+    char *device;
+    UINT64 period_usec;
+    struct list streams;
+    HANDLE timer_thread;
+    BOOL please_quit;
+    struct pipewire_stream *timer_stream;
+    UINT64 last_time;
+    BOOL grid_valid;
+};
+
 /* ----------------------------------------------------------------------
  * Globals
  * ---------------------------------------------------------------------- */
@@ -143,6 +158,7 @@ static pthread_mutex_t pw_init_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 static struct list g_render_devices = LIST_INIT(g_render_devices);
 static struct list g_capture_devices = LIST_INIT(g_capture_devices);
+static struct list active_periods = LIST_INIT(active_periods);
 static char g_default_sink[256];
 static char g_default_source[256];
 
@@ -1370,7 +1386,6 @@ static void on_stream_process(void *data)
             if (n < need_bytes)
             {
                 silence_buffer(stream->info.format, (BYTE *)d->data + n, need_bytes - n);
-                stream->just_underran = TRUE;
             }
             stream->pa_offs_bytes = (stream->pa_offs_bytes + n) % stream->real_bufsize_bytes;
             stream->pa_held_bytes -= n;
@@ -1566,6 +1581,12 @@ static NTSTATUS pipewire_create_stream(void *args)
     stream->share = params->share;
     stream->mmdev_period_usec = params->period / 10;
 
+    if (!(stream->device = strdup(params->device ? params->device : "")))
+    {
+        hr = E_OUTOFMEMORY;
+        goto exit;
+    }
+
     stream->period_bytes = stream->frame_size * muldiv(params->period, stream->info.rate, 10000000);
     if (stream->period_bytes == 0)
     {
@@ -1645,6 +1666,7 @@ exit:
             size = 0;
             NtFreeVirtualMemory(GetCurrentProcess(), (void **)&stream->capture_ring, &size, MEM_RELEASE);
         }
+        free(stream->device);
         free(stream);
     }
 
@@ -1656,22 +1678,42 @@ static NTSTATUS pipewire_release_stream(void *args)
 {
     struct release_stream_params *params = args;
     struct pipewire_stream *stream = handle_get_stream(params->stream);
+    struct pipewire_period *dead_period = NULL;
     SIZE_T size;
 
-    if (stream->timer_thread)
-    {
-        stream->please_quit = TRUE;
-        NtWaitForSingleObject(stream->timer_thread, FALSE, NULL);
-        NtClose(stream->timer_thread);
-    }
-
     pw_thread_loop_lock(pw_loop_global);
+    if (stream->period)
+    {
+        struct pipewire_period *period = stream->period;
+
+        if (period->timer_stream == stream)
+        {
+            period->timer_stream = NULL;
+            period->grid_valid = FALSE;
+        }
+        list_remove(&stream->period_entry);
+        stream->period = NULL;
+        if (list_empty(&period->streams))
+        {
+            list_remove(&period->entry);
+            period->please_quit = TRUE;
+            dead_period = period;
+        }
+    }
     if (stream->pw)
     {
         pw_stream_destroy(stream->pw);
         stream->pw = NULL;
     }
     pw_thread_loop_unlock(pw_loop_global);
+
+    if (dead_period)
+    {
+        NtWaitForSingleObject(dead_period->timer_thread, FALSE, NULL);
+        NtClose(dead_period->timer_thread);
+        free(dead_period->device);
+        free(dead_period);
+    }
 
     if (stream->tmp_buffer)
     {
@@ -1688,13 +1730,15 @@ static NTSTATUS pipewire_release_stream(void *args)
         size = 0;
         NtFreeVirtualMemory(GetCurrentProcess(), (void **)&stream->capture_ring, &size, MEM_RELEASE);
     }
+    free(stream->device);
     free(stream);
     params->result = S_OK;
     return STATUS_SUCCESS;
 }
 
 /* ----------------------------------------------------------------------
- * Capture slicing + timer thread (pulse_read / pulse_timer_loop transplant)
+ * Capture slicing + period group timer (8628-style shared timer; one Wine
+ * thread per (device, period) group)
  * ---------------------------------------------------------------------- */
 
 /* Slice period-sized packets out of the staging ring.  Runs on the Wine
@@ -1735,100 +1779,144 @@ static void pipewire_read(struct pipewire_stream *stream)
     }
 }
 
-static void pipewire_timer_loop(void *args)
+static void pipewire_period_timer_loop(void *args)
 {
-    struct pipewire_stream *stream = args;
+    struct pipewire_period *period = args;
+    struct pipewire_stream *stream;
     LARGE_INTEGER delay;
-    UINT64 last_time = 0, now;
     struct pw_time pwt;
+    UINT64 now = 0;
 
-    pw_thread_loop_lock(pw_loop_global);
-    delay.QuadPart = -(INT64)stream->mmdev_period_usec * 10;
-    if (stream->pw && pw_stream_get_time_n(stream->pw, &pwt, sizeof(pwt)) == 0 && pwt.now)
-        last_time = (UINT64)pwt.now / 1000;
-    pw_thread_loop_unlock(pw_loop_global);
+    delay.QuadPart = -(INT64)period->period_usec * 10;
 
-    while (!stream->please_quit)
+    while (!period->please_quit)
     {
         int have_now = 0;
 
         NtDelayExecution(FALSE, &delay);
 
         pw_thread_loop_lock(pw_loop_global);
-        delay.QuadPart = -(INT64)stream->mmdev_period_usec * 10;
+        delay.QuadPart = -(INT64)period->period_usec * 10;
 
-        if (stream->pw && pw_stream_get_time_n(stream->pw, &pwt, sizeof(pwt)) == 0 && pwt.now)
+        if (period->timer_stream && !period->timer_stream->started)
+        {
+            period->timer_stream = NULL;
+            period->grid_valid = FALSE;
+        }
+        if (!period->timer_stream)
+        {
+            LIST_FOR_EACH_ENTRY(stream, &period->streams, struct pipewire_stream, period_entry)
+            {
+                if (stream->started)
+                {
+                    period->timer_stream = stream;
+                    period->grid_valid = FALSE;
+                    break;
+                }
+            }
+        }
+
+        if (period->timer_stream && period->timer_stream->pw &&
+            pw_stream_get_time_n(period->timer_stream->pw, &pwt, sizeof(pwt)) == 0 && pwt.now)
         {
             now = (UINT64)pwt.now / 1000;
             have_now = 1;
         }
 
-        if (have_now)
+        if (!have_now)
+            period->grid_valid = FALSE;
+        else if (!period->grid_valid)
         {
-            if (stream->started && (stream->dataflow == eCapture || stream->held_bytes))
+            /* (re)acquire the grid; start draining next tick, mirroring the
+             * one-period start absorb of the old per-stream loop */
+            period->last_time = now;
+            period->grid_valid = TRUE;
+        }
+        else
+        {
+            INT32 adjust = period->last_time + period->period_usec - now;
+
+            if (adjust > (INT32)(period->period_usec / 2))
+                adjust = period->period_usec / 2;
+            else if (adjust < -(INT32)(period->period_usec / 2))
+                adjust = -(INT32)(period->period_usec / 2);
+
+            delay.QuadPart = -((INT64)period->period_usec + adjust) * 10;
+            period->last_time += period->period_usec;
+
+            LIST_FOR_EACH_ENTRY(stream, &period->streams, struct pipewire_stream, period_entry)
             {
-                if (stream->just_underran)
-                {
-                    last_time = now;
-                    stream->just_started = TRUE;
-                    stream->just_underran = FALSE;
-                }
-
-                if (stream->just_started)
-                {
-                    /* play out a period to absorb latency and get timing */
-                    if (now - last_time > stream->mmdev_period_usec)
-                    {
-                        stream->just_started = FALSE;
-                        last_time = now;
-                    }
-                }
-                else
-                {
-                    INT32 adjust = last_time + stream->mmdev_period_usec - now;
-
-                    if (adjust > (INT32)(stream->mmdev_period_usec / 2))
-                        adjust = stream->mmdev_period_usec / 2;
-                    else if (adjust < -(INT32)(stream->mmdev_period_usec / 2))
-                        adjust = -(INT32)(stream->mmdev_period_usec / 2);
-
-                    delay.QuadPart = -((INT64)stream->mmdev_period_usec + adjust) * 10;
-                    last_time += stream->mmdev_period_usec;
-                }
-
+                if (!stream->started)
+                    continue;
                 if (stream->dataflow == eRender)
                 {
-                    /* advance one period regardless of what the device does */
                     UINT32 adv = min(stream->period_bytes, stream->held_bytes);
                     stream->lcl_offs_bytes += adv;
                     stream->lcl_offs_bytes %= stream->real_bufsize_bytes;
                     stream->held_bytes -= adv;
                 }
                 else
-                {
                     pipewire_read(stream);
-                }
-            }
-            else
-            {
-                last_time = now;
-                delay.QuadPart = -(INT64)stream->mmdev_period_usec * 10;
             }
         }
 
-        if (stream->event)
-            NtSetEvent(stream->event, NULL);
+        LIST_FOR_EACH_ENTRY(stream, &period->streams, struct pipewire_stream, period_entry)
+            if (stream->event)
+                NtSetEvent(stream->event, NULL);
 
         pw_thread_loop_unlock(pw_loop_global);
     }
     PsTerminateSystemThread(0);
 }
 
+/* Called with the loop lock held. */
+static HRESULT pipewire_add_stream_to_period(struct pipewire_stream *stream)
+{
+    static const WCHAR name[] = {'w','i','n','e','p','i','p','e','w','i','r','e','_','t','i','m','e','r',0};
+    struct pipewire_period *period;
+
+    if (stream->period)
+        return S_OK;
+
+    LIST_FOR_EACH_ENTRY(period, &active_periods, struct pipewire_period, entry)
+    {
+        if (period->period_usec == stream->mmdev_period_usec && !strcmp(period->device, stream->device))
+        {
+            stream->period = period;
+            list_add_tail(&period->streams, &stream->period_entry);
+            return S_OK;
+        }
+    }
+
+    if (!(period = calloc(1, sizeof(*period))))
+        return E_OUTOFMEMORY;
+    if (!(period->device = strdup(stream->device)))
+    {
+        free(period);
+        return E_OUTOFMEMORY;
+    }
+    period->period_usec = stream->mmdev_period_usec;
+    list_init(&period->streams);
+    stream->period = period;
+    list_add_tail(&period->streams, &stream->period_entry);
+    list_add_tail(&active_periods, &period->entry);
+
+    if (create_unix_thread(&period->timer_thread, name, pipewire_period_timer_loop, period))
+    {
+        list_remove(&stream->period_entry);
+        list_remove(&period->entry);
+        stream->period = NULL;
+        free(period->device);
+        free(period);
+        return E_FAIL;
+    }
+    return S_OK;
+}
+
 static NTSTATUS pipewire_start(void *args)
 {
     struct start_params *params = args;
     struct pipewire_stream *stream = handle_get_stream(params->stream);
-    static const WCHAR name[] = {'w','i','n','e','p','i','p','e','w','i','r','e','_','t','i','m','e','r',0};
 
     params->result = S_OK;
     pw_thread_loop_lock(pw_loop_global);
@@ -1853,13 +1941,15 @@ static NTSTATUS pipewire_start(void *args)
         return STATUS_SUCCESS;
     }
 
+    if (FAILED(params->result = pipewire_add_stream_to_period(stream)))
+    {
+        pw_thread_loop_unlock(pw_loop_global);
+        return STATUS_SUCCESS;
+    }
+
     pw_stream_set_active(stream->pw, true);
     stream->started = TRUE;
-    stream->just_started = TRUE;
     pw_thread_loop_unlock(pw_loop_global);
-
-    if (!stream->timer_thread)
-        create_unix_thread(&stream->timer_thread, name, pipewire_timer_loop, stream);
     return STATUS_SUCCESS;
 }
 

--- a/dlls/winepipewire.drv/pipewire.c
+++ b/dlls/winepipewire.drv/pipewire.c
@@ -250,6 +250,30 @@ static void copy_from_ring(BYTE *dst, const BYTE *ring, SIZE_T ring_size, SIZE_T
         memcpy(dst + first, ring, n - first);
 }
 
+/* Parse {"name":"<value>"} metadata values.  spa_json_str_object_find needs
+ * PipeWire 1.4; this uses only the stable spa_json core (verified in 1.0.0). */
+static int parse_json_str_field(const char *json, const char *field, char *dst, size_t maxlen)
+{
+    struct spa_json it[2];
+    char key[64];
+    const char *val;
+    int len;
+
+    spa_json_init(&it[0], json, strlen(json));
+    if (spa_json_enter_object(&it[0], &it[1]) <= 0)
+        return -1;
+    while (spa_json_get_string(&it[1], key, sizeof(key)) > 0)
+    {
+        if (!strcmp(key, field))
+            return spa_json_get_string(&it[1], dst, maxlen) > 0 ? 0 : -1;
+        if ((len = spa_json_next(&it[1], &val)) <= 0)
+            return -1;
+        if (spa_json_is_container(val, len) && spa_json_container_len(&it[1], val, len) <= 0)
+            return -1;
+    }
+    return -1;
+}
+
 /* SPA channel position -> WASAPI speaker bit */
 static UINT spa_position_to_mask_bit(uint32_t pos)
 {
@@ -656,7 +680,7 @@ static int on_probe_metadata_property(void *data, uint32_t subject, const char *
         dst = p->default_source;
     else
         return 0;
-    spa_json_str_object_find(value, strlen(value), "name", dst, 256);
+    parse_json_str_field(value, "name", dst, 256);
     return 0;
 }
 

--- a/dlls/winepipewire.drv/pipewire.c
+++ b/dlls/winepipewire.drv/pipewire.c
@@ -1499,11 +1499,11 @@ static HRESULT pipewire_stream_connect(struct pipewire_stream *stream, const cha
         pw_properties_set(props, PW_KEY_NODE_NAME, "winepipewire");
     pw_properties_setf(props, PW_KEY_NODE_LATENCY, "%u/%u", period_frames, stream->info.rate);
     if (device && device[0])
-    {
         pw_properties_set(props, PW_KEY_TARGET_OBJECT, device);
-        if (stream->dataflow == eCapture && device_is_sink(device))
-            pw_properties_set(props, PW_KEY_STREAM_CAPTURE_SINK, "true");
-    }
+    if (stream->dataflow == eCapture &&
+        ((stream->flags & AUDCLNT_STREAMFLAGS_LOOPBACK) ||
+         (device && device[0] && device_is_sink(device))))
+        pw_properties_set(props, PW_KEY_STREAM_CAPTURE_SINK, "true");
 
     stream->pw = pw_stream_new(pw_core_global, "winepipewire", props);
     if (!stream->pw)

--- a/dlls/winepipewire.drv/pipewire.c
+++ b/dlls/winepipewire.drv/pipewire.c
@@ -1,0 +1,2560 @@
+/*
+ * PipeWire audio driver for Wine
+ *
+ * Copyright 2026 M0n7y5
+ *
+ * The WASAPI ring-buffer, timer, clock, volume and packet mechanics in this
+ * file are transplanted from Wine's winepulse.drv (pulse.c) and remain under
+ * its notice:
+ *   Copyright 2011-2012 Maarten Lankhorst
+ *   Copyright 2010-2011 Maarten Lankhorst for CodeWeavers
+ *   Copyright 2011 Andrew Eikum for CodeWeavers
+ *   Copyright 2022 Huw Davies
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#if 0
+#pragma makedep unix
+#endif
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+
+#include <pipewire/pipewire.h>
+#include <pipewire/extensions/metadata.h>
+#include <spa/param/param.h>
+#include <spa/param/props.h>
+#include <spa/param/audio/format-utils.h>
+#include <spa/utils/json.h>
+
+#include "ntstatus.h"
+#include "winternl.h"
+
+#include "mmdeviceapi.h"
+#include "initguid.h"
+#include "audioclient.h"
+
+#include "wine/debug.h"
+#include "wine/list.h"
+#include "wine/unixlib.h"
+
+#include "../mmdevapi/unixlib.h"
+
+WINE_DEFAULT_DEBUG_CHANNEL(pipewire);
+
+#define PW_CHANNELS_MAX 64
+
+/* ----------------------------------------------------------------------
+ * Stream and device structures (struct pulse_stream transplant)
+ * ---------------------------------------------------------------------- */
+
+struct pipewire_stream
+{
+    EDataFlow dataflow;
+
+    struct pw_stream *pw;
+    struct spa_hook stream_listener;
+    struct spa_audio_info_raw info;
+    UINT32 frame_size;
+
+    DWORD flags;
+    AUDCLNT_SHAREMODE share;
+    HANDLE event;
+    HANDLE timer_thread;
+    float vol[PW_CHANNELS_MAX];
+
+    REFERENCE_TIME def_period;
+    REFERENCE_TIME duration;
+
+    INT32 locked;
+    BOOL started;
+    SIZE_T bufsize_frames, real_bufsize_bytes, period_bytes;
+    SIZE_T lcl_offs_bytes, pa_offs_bytes;
+    SIZE_T tmp_buffer_bytes, held_bytes, pa_held_bytes;
+    BYTE *local_buffer, *tmp_buffer;
+    void *locked_ptr;
+    BOOL please_quit, just_started, just_underran;
+    UINT64 mmdev_period_usec;
+
+    /* capture staging ring: the analogue of PulseAudio's internal record
+     * buffer.  The pw_stream process callback (a foreign pthread) appends
+     * raw bytes here; the Wine timer thread slices period-sized ACPackets
+     * out of it with QPC timestamps. */
+    BYTE *capture_ring;
+    SIZE_T capture_ring_size, cap_read_offs, cap_held_bytes;
+
+    INT64 clock_lastpos, clock_written;
+
+    struct list packet_free_head;
+    struct list packet_filled_head;
+};
+
+typedef struct _ACPacket
+{
+    struct list entry;
+    UINT64 qpcpos;
+    BYTE *data;
+    UINT32 discont;
+} ACPacket;
+
+struct pw_phys_device
+{
+    struct list entry;
+    WCHAR *display;
+    EndpointFormFactor form;
+    UINT channel_mask;
+    REFERENCE_TIME min_period, def_period;
+    WAVEFORMATEXTENSIBLE fmt;
+    char pw_name[];
+};
+
+/* ----------------------------------------------------------------------
+ * Globals
+ * ---------------------------------------------------------------------- */
+
+static struct pw_thread_loop *pw_loop_global;
+static struct pw_context *pw_ctx;
+static struct pw_core *pw_core_global;
+static struct spa_hook core_listener;
+static BOOL core_listener_added;
+static BOOL core_dead;
+
+static pthread_mutex_t pw_init_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+static struct list g_render_devices = LIST_INIT(g_render_devices);
+static struct list g_capture_devices = LIST_INIT(g_capture_devices);
+static char g_default_sink[256];
+static char g_default_source[256];
+
+/* ----------------------------------------------------------------------
+ * Small helpers
+ * ---------------------------------------------------------------------- */
+
+/* copied from kernelbase */
+static int muldiv(int a, int b, int c)
+{
+    LONGLONG ret;
+
+    if (!c) return -1;
+
+    if (c < 0)
+    {
+        a = -a;
+        c = -c;
+    }
+
+    if ((a < 0 && b < 0) || (a >= 0 && b >= 0))
+        ret = (((LONGLONG)a * b) + (c / 2)) / c;
+    else
+        ret = (((LONGLONG)a * b) - (c / 2)) / c;
+
+    if (ret > 2147483647 || ret < -2147483647) return -1;
+    return ret;
+}
+
+static char *wstr_to_str(const WCHAR *wstr)
+{
+    const int len = wcslen(wstr);
+    char *str = malloc(len * 3 + 1);
+    if (!str) return NULL;
+    ntdll_wcstoumbs(wstr, len + 1, str, len * 3 + 1, FALSE);
+    return str;
+}
+
+static WCHAR *utf8_to_wstr(const char *s)
+{
+    size_t len = strlen(s);
+    WCHAR *w = malloc((len + 1) * sizeof(WCHAR));
+    DWORD n;
+
+    if (!w) return NULL;
+    n = ntdll_umbstowcs(s, len, w, len);
+    w[n] = '\0';
+    return w;
+}
+
+static struct pipewire_stream *handle_get_stream(stream_handle h)
+{
+    return (struct pipewire_stream *)(UINT_PTR)h;
+}
+
+static UINT spa_format_bytes(enum spa_audio_format f)
+{
+    switch (f)
+    {
+    case SPA_AUDIO_FORMAT_U8:
+    case SPA_AUDIO_FORMAT_S8:
+        return 1;
+    case SPA_AUDIO_FORMAT_S16_LE:
+        return 2;
+    case SPA_AUDIO_FORMAT_S24_LE:
+        return 3;
+    case SPA_AUDIO_FORMAT_S32_LE:
+    case SPA_AUDIO_FORMAT_S24_32_LE:
+    case SPA_AUDIO_FORMAT_F32_LE:
+        return 4;
+    default:
+        return 0;
+    }
+}
+
+static void silence_buffer(enum spa_audio_format format, BYTE *buffer, UINT32 bytes)
+{
+    memset(buffer, format == SPA_AUDIO_FORMAT_U8 ? 0x80 : 0, bytes);
+}
+
+/* copy n bytes out of a byte ring starting at offs, wrapping at ring_size */
+static void copy_from_ring(BYTE *dst, const BYTE *ring, SIZE_T ring_size, SIZE_T offs, SIZE_T n)
+{
+    SIZE_T first = min(n, ring_size - offs);
+    memcpy(dst, ring + offs, first);
+    if (n > first)
+        memcpy(dst + first, ring, n - first);
+}
+
+/* SPA channel position -> WASAPI speaker bit */
+static UINT spa_position_to_mask_bit(uint32_t pos)
+{
+    switch (pos)
+    {
+    case SPA_AUDIO_CHANNEL_MONO:
+    case SPA_AUDIO_CHANNEL_FC:   return SPEAKER_FRONT_CENTER;
+    case SPA_AUDIO_CHANNEL_FL:   return SPEAKER_FRONT_LEFT;
+    case SPA_AUDIO_CHANNEL_FR:   return SPEAKER_FRONT_RIGHT;
+    case SPA_AUDIO_CHANNEL_LFE:  return SPEAKER_LOW_FREQUENCY;
+    case SPA_AUDIO_CHANNEL_RL:   return SPEAKER_BACK_LEFT;
+    case SPA_AUDIO_CHANNEL_RR:   return SPEAKER_BACK_RIGHT;
+    case SPA_AUDIO_CHANNEL_FLC:  return SPEAKER_FRONT_LEFT_OF_CENTER;
+    case SPA_AUDIO_CHANNEL_FRC:  return SPEAKER_FRONT_RIGHT_OF_CENTER;
+    case SPA_AUDIO_CHANNEL_RC:   return SPEAKER_BACK_CENTER;
+    case SPA_AUDIO_CHANNEL_SL:   return SPEAKER_SIDE_LEFT;
+    case SPA_AUDIO_CHANNEL_SR:   return SPEAKER_SIDE_RIGHT;
+    case SPA_AUDIO_CHANNEL_TC:   return SPEAKER_TOP_CENTER;
+    case SPA_AUDIO_CHANNEL_TFL:  return SPEAKER_TOP_FRONT_LEFT;
+    case SPA_AUDIO_CHANNEL_TFC:  return SPEAKER_TOP_FRONT_CENTER;
+    case SPA_AUDIO_CHANNEL_TFR:  return SPEAKER_TOP_FRONT_RIGHT;
+    case SPA_AUDIO_CHANNEL_TRL:  return SPEAKER_TOP_BACK_LEFT;
+    case SPA_AUDIO_CHANNEL_TRC:  return SPEAKER_TOP_BACK_CENTER;
+    case SPA_AUDIO_CHANNEL_TRR:  return SPEAKER_TOP_BACK_RIGHT;
+    default:                     return 0;
+    }
+}
+
+static UINT positions_to_mask(const uint32_t *pos, uint32_t channels)
+{
+    UINT mask = 0, i;
+    for (i = 0; i < channels; i++)
+        mask |= spa_position_to_mask_bit(pos[i]);
+    return mask;
+}
+
+/* WASAPI speaker bit index -> SPA channel position (inverse table) */
+static const uint32_t spa_pos_from_wfx[] = {
+    SPA_AUDIO_CHANNEL_FL,   /* SPEAKER_FRONT_LEFT */
+    SPA_AUDIO_CHANNEL_FR,   /* SPEAKER_FRONT_RIGHT */
+    SPA_AUDIO_CHANNEL_FC,   /* SPEAKER_FRONT_CENTER */
+    SPA_AUDIO_CHANNEL_LFE,  /* SPEAKER_LOW_FREQUENCY */
+    SPA_AUDIO_CHANNEL_RL,   /* SPEAKER_BACK_LEFT */
+    SPA_AUDIO_CHANNEL_RR,   /* SPEAKER_BACK_RIGHT */
+    SPA_AUDIO_CHANNEL_FLC,  /* SPEAKER_FRONT_LEFT_OF_CENTER */
+    SPA_AUDIO_CHANNEL_FRC,  /* SPEAKER_FRONT_RIGHT_OF_CENTER */
+    SPA_AUDIO_CHANNEL_RC,   /* SPEAKER_BACK_CENTER */
+    SPA_AUDIO_CHANNEL_SL,   /* SPEAKER_SIDE_LEFT */
+    SPA_AUDIO_CHANNEL_SR,   /* SPEAKER_SIDE_RIGHT */
+    SPA_AUDIO_CHANNEL_TC,   /* SPEAKER_TOP_CENTER */
+    SPA_AUDIO_CHANNEL_TFL,  /* SPEAKER_TOP_FRONT_LEFT */
+    SPA_AUDIO_CHANNEL_TFC,  /* SPEAKER_TOP_FRONT_CENTER */
+    SPA_AUDIO_CHANNEL_TFR,  /* SPEAKER_TOP_FRONT_RIGHT */
+    SPA_AUDIO_CHANNEL_TRL,  /* SPEAKER_TOP_BACK_LEFT */
+    SPA_AUDIO_CHANNEL_TRC,  /* SPEAKER_TOP_BACK_CENTER */
+    SPA_AUDIO_CHANNEL_TRR,  /* SPEAKER_TOP_BACK_RIGHT */
+};
+
+static UINT get_channel_mask(unsigned int channels)
+{
+    switch (channels)
+    {
+    case 0:  return 0;
+    case 1:  return KSAUDIO_SPEAKER_MONO;
+    case 2:  return KSAUDIO_SPEAKER_STEREO;
+    case 3:  return KSAUDIO_SPEAKER_STEREO | SPEAKER_LOW_FREQUENCY;
+    case 4:  return KSAUDIO_SPEAKER_QUAD;
+    case 5:  return KSAUDIO_SPEAKER_QUAD | SPEAKER_LOW_FREQUENCY;
+    case 6:  return KSAUDIO_SPEAKER_5POINT1;
+    case 7:  return KSAUDIO_SPEAKER_5POINT1 | SPEAKER_BACK_CENTER;
+    case 8:  return KSAUDIO_SPEAKER_7POINT1_SURROUND;
+    }
+    FIXME("Unknown speaker configuration: %u\n", channels);
+    return 0;
+}
+
+/* find the nearest Windows-reportable channel configuration that is a
+ * superset of the given speakers (transplant of pulse convert_channel_map) */
+static void convert_channel_map(uint32_t channels, UINT mask, WAVEFORMATEXTENSIBLE *fmt)
+{
+    if (channels == 1)
+    {
+        fmt->Format.nChannels = 1;
+        fmt->dwChannelMask = mask;
+        return;
+    }
+    if (channels <= 2 && (mask & ~KSAUDIO_SPEAKER_STEREO) == 0)
+    {
+        fmt->Format.nChannels = 2;
+        fmt->dwChannelMask = KSAUDIO_SPEAKER_STEREO;
+        return;
+    }
+    if (channels <= 4 && (mask & ~KSAUDIO_SPEAKER_QUAD) == 0)
+    {
+        fmt->Format.nChannels = 4;
+        fmt->dwChannelMask = KSAUDIO_SPEAKER_QUAD;
+        return;
+    }
+    if (channels <= 4 && (mask & ~KSAUDIO_SPEAKER_SURROUND) == 0)
+    {
+        fmt->Format.nChannels = 4;
+        fmt->dwChannelMask = KSAUDIO_SPEAKER_SURROUND;
+        return;
+    }
+    if (channels <= 6 && (mask & ~KSAUDIO_SPEAKER_5POINT1) == 0)
+    {
+        fmt->Format.nChannels = 6;
+        fmt->dwChannelMask = KSAUDIO_SPEAKER_5POINT1;
+        return;
+    }
+    if (channels <= 6 && (mask & ~KSAUDIO_SPEAKER_5POINT1_SURROUND) == 0)
+    {
+        fmt->Format.nChannels = 6;
+        fmt->dwChannelMask = KSAUDIO_SPEAKER_5POINT1_SURROUND;
+        return;
+    }
+    if (channels <= 8 && (mask & ~KSAUDIO_SPEAKER_7POINT1) == 0)
+    {
+        fmt->Format.nChannels = 8;
+        fmt->dwChannelMask = KSAUDIO_SPEAKER_7POINT1;
+        return;
+    }
+    if (channels <= 8 && (mask & ~KSAUDIO_SPEAKER_7POINT1_SURROUND) == 0)
+    {
+        fmt->Format.nChannels = 8;
+        fmt->dwChannelMask = KSAUDIO_SPEAKER_7POINT1_SURROUND;
+        return;
+    }
+    fmt->Format.nChannels = channels;
+    fmt->dwChannelMask = mask;
+}
+
+static void build_format(WAVEFORMATEXTENSIBLE *fmt, uint32_t rate, uint32_t channels, UINT mask)
+{
+    WAVEFORMATEX *wfx = &fmt->Format;
+
+    wfx->wFormatTag = WAVE_FORMAT_EXTENSIBLE;
+    wfx->cbSize = sizeof(WAVEFORMATEXTENSIBLE) - sizeof(WAVEFORMATEX);
+    convert_channel_map(channels, mask, fmt);
+    wfx->wBitsPerSample = 32;
+    wfx->nSamplesPerSec = rate ? rate : 48000;
+    wfx->nBlockAlign = wfx->nChannels * wfx->wBitsPerSample / 8;
+    wfx->nAvgBytesPerSec = wfx->nSamplesPerSec * wfx->nBlockAlign;
+    fmt->Samples.wValidBitsPerSample = 32;
+    fmt->SubFormat = KSDATAFORMAT_SUBTYPE_IEEE_FLOAT;
+}
+
+static struct pw_phys_device *add_device(struct list *list, const char *pw_name, const char *display,
+                                         EndpointFormFactor form, uint32_t rate, uint32_t channels, UINT mask)
+{
+    size_t len = strlen(pw_name);
+    struct pw_phys_device *dev = malloc(offsetof(struct pw_phys_device, pw_name) + len + 1);
+
+    if (!dev)
+        return NULL;
+    if (!(dev->display = utf8_to_wstr(display)))
+    {
+        free(dev);
+        return NULL;
+    }
+    dev->form = form;
+    build_format(&dev->fmt, rate, channels, mask);
+    dev->channel_mask = dev->fmt.dwChannelMask;
+    dev->def_period = 100000;
+    dev->min_period = 50000;
+    memcpy(dev->pw_name, pw_name, len + 1);
+    list_add_tail(list, &dev->entry);
+    TRACE("%s (%s) channels=%u mask=%#x\n", debugstr_w(dev->display), pw_name,
+          dev->fmt.Format.nChannels, dev->channel_mask);
+    return dev;
+}
+
+static void free_device_lists(void)
+{
+    static struct list *const lists[] = { &g_render_devices, &g_capture_devices, NULL };
+    struct list *const *list = lists;
+    struct pw_phys_device *dev, *next;
+
+    do {
+        LIST_FOR_EACH_ENTRY_SAFE(dev, next, *list, struct pw_phys_device, entry)
+        {
+            list_remove(&dev->entry);
+            free(dev->display);
+            free(dev);
+        }
+    } while (*(++list));
+}
+
+/* ----------------------------------------------------------------------
+ * Process attach / detach
+ * ---------------------------------------------------------------------- */
+
+static NTSTATUS pipewire_process_attach(void *args)
+{
+    pw_init(NULL, NULL);
+    TRACE("PipeWire %s, header %s\n", pw_get_library_version(), pw_get_headers_version());
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_process_detach(void *args)
+{
+    free_device_lists();
+    pw_deinit();
+    return STATUS_SUCCESS;
+}
+
+/* ----------------------------------------------------------------------
+ * Connection / main loop
+ * ---------------------------------------------------------------------- */
+
+static void on_core_error(void *data, uint32_t id, int seq, int res, const char *message)
+{
+    /* Runs on the PipeWire loop thread: pw API only, no ntdll/Wine calls. */
+    if (id == PW_ID_CORE)
+    {
+        core_dead = TRUE;
+        if (pw_loop_global)
+            pw_thread_loop_signal(pw_loop_global, false);
+    }
+}
+
+static const struct pw_core_events core_events = {
+    PW_VERSION_CORE_EVENTS,
+    .error = on_core_error,
+};
+
+/* Called with the loop lock held. */
+static HRESULT pipewire_connect(void)
+{
+    if (pw_core_global && !core_dead)
+        return S_OK;
+
+    if (pw_core_global)
+    {
+        if (core_listener_added)
+        {
+            spa_hook_remove(&core_listener);
+            core_listener_added = FALSE;
+        }
+        pw_core_disconnect(pw_core_global);
+        pw_core_global = NULL;
+    }
+    core_dead = FALSE;
+
+    if (!(pw_core_global = pw_context_connect(pw_ctx, NULL, 0)))
+    {
+        WARN("pw_context_connect failed\n");
+        return AUDCLNT_E_ENDPOINT_CREATE_FAILED;
+    }
+    pw_core_add_listener(pw_core_global, &core_listener, &core_events, NULL);
+    core_listener_added = TRUE;
+    return S_OK;
+}
+
+static NTSTATUS pipewire_main_loop_start(void *args)
+{
+    pthread_mutex_lock(&pw_init_mutex);
+    if (pw_loop_global)
+        goto out;
+
+    if (!(pw_loop_global = pw_thread_loop_new("winepipewire", NULL)))
+    {
+        ERR("pw_thread_loop_new failed\n");
+        goto out;
+    }
+    if (!(pw_ctx = pw_context_new(pw_thread_loop_get_loop(pw_loop_global), NULL, 0)))
+    {
+        ERR("pw_context_new failed\n");
+        pw_thread_loop_destroy(pw_loop_global);
+        pw_loop_global = NULL;
+        goto out;
+    }
+    pw_thread_loop_start(pw_loop_global);
+
+out:
+    pthread_mutex_unlock(&pw_init_mutex);
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_main_loop_stop(void *args)
+{
+    pthread_mutex_lock(&pw_init_mutex);
+    if (pw_loop_global)
+    {
+        pw_thread_loop_lock(pw_loop_global);
+        if (pw_core_global)
+        {
+            if (core_listener_added)
+            {
+                spa_hook_remove(&core_listener);
+                core_listener_added = FALSE;
+            }
+            pw_core_disconnect(pw_core_global);
+            pw_core_global = NULL;
+        }
+        pw_thread_loop_unlock(pw_loop_global);
+        pw_thread_loop_stop(pw_loop_global);
+        if (pw_ctx)
+        {
+            pw_context_destroy(pw_ctx);
+            pw_ctx = NULL;
+        }
+        pw_thread_loop_destroy(pw_loop_global);
+        pw_loop_global = NULL;
+    }
+    pthread_mutex_unlock(&pw_init_mutex);
+    return STATUS_SUCCESS;
+}
+
+/* ----------------------------------------------------------------------
+ * Probe: device enumeration, defaults, formats (test_connect)
+ *
+ * All registry / node / metadata / core callbacks below run on the probe
+ * thread loop's own (foreign) thread.  They may only call libc, spa and pw
+ * APIs -- never ntdll/Wine (no TRACE).  Strings are kept as UTF-8 and
+ * converted to UTF-16 later, on the unix-call thread.
+ * ---------------------------------------------------------------------- */
+
+struct probe_node
+{
+    struct list entry;
+    uint32_t id;
+    EDataFlow flow;
+    char *node_name;
+    char *display;
+    struct pw_node *proxy;
+    struct spa_hook listener;
+    uint32_t channels;
+    uint32_t position[SPA_AUDIO_MAX_CHANNELS];
+    int have_format;
+};
+
+struct probe
+{
+    struct pw_thread_loop *loop;
+    struct pw_context *context;
+    struct pw_core *core;
+    struct pw_registry *registry;
+    struct spa_hook core_listener;
+    struct spa_hook registry_listener;
+    int sync_seq;
+    struct list nodes;
+    struct pw_metadata *meta_default;
+    struct pw_metadata *meta_settings;
+    struct spa_hook meta_default_listener;
+    struct spa_hook meta_settings_listener;
+    char default_sink[256];
+    char default_source[256];
+    uint32_t clock_rate;
+};
+
+static void on_probe_node_param(void *data, int seq, uint32_t id, uint32_t index,
+                                uint32_t next, const struct spa_pod *param)
+{
+    struct probe_node *pn = data;
+    struct spa_audio_info_raw info;
+
+    if (!param || id != SPA_PARAM_EnumFormat)
+        return;
+    spa_zero(info);
+    if (spa_format_audio_raw_parse(param, &info) < 0)
+        return;
+    if (info.channels < 1 || info.channels > SPA_AUDIO_MAX_CHANNELS)
+        return;
+    /* Keep the configuration with the most channels: best surround coverage. */
+    if (!pn->have_format || info.channels > pn->channels)
+    {
+        pn->channels = info.channels;
+        memcpy(pn->position, info.position, sizeof(info.position));
+        pn->have_format = 1;
+    }
+}
+
+static const struct pw_node_events probe_node_events = {
+    PW_VERSION_NODE_EVENTS,
+    .param = on_probe_node_param,
+};
+
+static int on_probe_metadata_property(void *data, uint32_t subject, const char *key,
+                                      const char *type, const char *value)
+{
+    struct probe *p = data;
+    char *dst;
+
+    if (!key || !value)
+        return 0;
+    if (!strcmp(key, "default.audio.sink"))
+        dst = p->default_sink;
+    else if (!strcmp(key, "default.audio.source"))
+        dst = p->default_source;
+    else
+        return 0;
+    spa_json_str_object_find(value, strlen(value), "name", dst, 256);
+    return 0;
+}
+
+static const struct pw_metadata_events probe_metadata_events = {
+    PW_VERSION_METADATA_EVENTS,
+    .property = on_probe_metadata_property,
+};
+
+static int on_probe_settings_property(void *data, uint32_t subject, const char *key,
+                                      const char *type, const char *value)
+{
+    struct probe *p = data;
+
+    if (!key || !value)
+        return 0;
+    if (!strcmp(key, "clock.force-rate"))
+    {
+        uint32_t r = (uint32_t)strtoul(value, NULL, 10);
+        if (r)
+            p->clock_rate = r;
+    }
+    else if (!strcmp(key, "clock.rate") && !p->clock_rate)
+    {
+        p->clock_rate = (uint32_t)strtoul(value, NULL, 10);
+    }
+    return 0;
+}
+
+static const struct pw_metadata_events probe_settings_events = {
+    PW_VERSION_METADATA_EVENTS,
+    .property = on_probe_settings_property,
+};
+
+static void on_probe_registry_global(void *data, uint32_t id, uint32_t permissions,
+                                      const char *type, uint32_t version,
+                                      const struct spa_dict *props)
+{
+    struct probe *p = data;
+
+    if (!type || !props)
+        return;
+
+    if (!strcmp(type, PW_TYPE_INTERFACE_Node))
+    {
+        const char *media_class = spa_dict_lookup(props, PW_KEY_MEDIA_CLASS);
+        const char *node_name = spa_dict_lookup(props, PW_KEY_NODE_NAME);
+        const char *desc = spa_dict_lookup(props, PW_KEY_NODE_DESCRIPTION);
+        const char *nick = spa_dict_lookup(props, PW_KEY_NODE_NICK);
+        struct probe_node *pn;
+
+        if (!media_class || !node_name)
+            return;
+        if (strcmp(media_class, "Audio/Sink") && strcmp(media_class, "Audio/Source"))
+            return;
+
+        if (!(pn = calloc(1, sizeof(*pn))))
+            return;
+        pn->id = id;
+        pn->flow = !strcmp(media_class, "Audio/Sink") ? eRender : eCapture;
+        pn->node_name = strdup(node_name);
+        pn->display = strdup(desc ? desc : (nick ? nick : node_name));
+        list_add_tail(&p->nodes, &pn->entry);
+
+        /* Bind the node and ask for its supported formats so we can report
+         * the real channel layout.  The param events arrive during the sync
+         * round-trips below. */
+        pn->proxy = pw_registry_bind(p->registry, id, PW_TYPE_INTERFACE_Node, PW_VERSION_NODE, 0);
+        if (pn->proxy)
+        {
+            pw_node_add_listener(pn->proxy, &pn->listener, &probe_node_events, pn);
+            pw_node_enum_params(pn->proxy, 0, SPA_PARAM_EnumFormat, 0, UINT32_MAX, NULL);
+        }
+    }
+    else if (!strcmp(type, PW_TYPE_INTERFACE_Metadata))
+    {
+        const char *name = spa_dict_lookup(props, PW_KEY_METADATA_NAME);
+        if (!name)
+            return;
+        if (!strcmp(name, "default") && !p->meta_default)
+        {
+            p->meta_default = pw_registry_bind(p->registry, id, PW_TYPE_INTERFACE_Metadata,
+                                               PW_VERSION_METADATA, 0);
+            if (p->meta_default)
+                pw_metadata_add_listener(p->meta_default, &p->meta_default_listener,
+                                         &probe_metadata_events, p);
+        }
+        else if (!strcmp(name, "settings") && !p->meta_settings)
+        {
+            p->meta_settings = pw_registry_bind(p->registry, id, PW_TYPE_INTERFACE_Metadata,
+                                                PW_VERSION_METADATA, 0);
+            if (p->meta_settings)
+                pw_metadata_add_listener(p->meta_settings, &p->meta_settings_listener,
+                                         &probe_settings_events, p);
+        }
+    }
+}
+
+static void on_probe_registry_global_remove(void *data, uint32_t id)
+{
+}
+
+static const struct pw_registry_events probe_registry_events = {
+    PW_VERSION_REGISTRY_EVENTS,
+    .global = on_probe_registry_global,
+    .global_remove = on_probe_registry_global_remove,
+};
+
+static void on_probe_core_done(void *data, uint32_t id, int seq)
+{
+    struct probe *p = data;
+    if (id == PW_ID_CORE && seq == p->sync_seq)
+        pw_thread_loop_signal(p->loop, false);
+}
+
+static const struct pw_core_events probe_core_events = {
+    PW_VERSION_CORE_EVENTS,
+    .done = on_probe_core_done,
+};
+
+/* Round-trip the core; must be called with the loop lock held. */
+static void probe_roundtrip(struct probe *p)
+{
+    p->sync_seq = pw_core_sync(p->core, PW_ID_CORE, p->sync_seq);
+    pw_thread_loop_timed_wait(p->loop, 2);
+}
+
+static void build_device_cache(struct probe *p)
+{
+    struct probe_node *pn;
+    struct pw_phys_device *dev, *def_src, *def;
+    uint32_t rate = p->clock_rate ? p->clock_rate : 48000;
+
+    lstrcpynA(g_default_sink, p->default_sink, sizeof(g_default_sink));
+    lstrcpynA(g_default_source, p->default_source, sizeof(g_default_source));
+
+    LIST_FOR_EACH_ENTRY(pn, &p->nodes, struct probe_node, entry)
+    {
+        struct list *list = (pn->flow == eRender) ? &g_render_devices : &g_capture_devices;
+        EndpointFormFactor form = (pn->flow == eRender) ? Speakers : Microphone;
+        uint32_t channels = pn->have_format ? pn->channels : 2;
+        UINT mask = pn->have_format ? positions_to_mask(pn->position, pn->channels)
+                                    : (SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT);
+        add_device(list, pn->node_name, pn->display, form, rate, channels, mask);
+    }
+
+    /* Synthetic default render device at index 0 (empty pw_name -> session
+     * manager default routing). */
+    def_src = NULL;
+    if (g_default_sink[0])
+    {
+        LIST_FOR_EACH_ENTRY(dev, &g_render_devices, struct pw_phys_device, entry)
+            if (!strcmp(dev->pw_name, g_default_sink)) { def_src = dev; break; }
+    }
+    if ((def = malloc(offsetof(struct pw_phys_device, pw_name) + 1)))
+    {
+        def->pw_name[0] = '\0';
+        def->display = utf8_to_wstr("PipeWire");
+        def->form = Speakers;
+        def->def_period = 100000;
+        def->min_period = 50000;
+        if (def_src)
+        {
+            def->fmt = def_src->fmt;
+            def->channel_mask = def_src->channel_mask;
+        }
+        else
+        {
+            build_format(&def->fmt, rate, 2, SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT);
+            def->channel_mask = def->fmt.dwChannelMask;
+        }
+        list_add_head(&g_render_devices, &def->entry);
+    }
+
+    def_src = NULL;
+    if (g_default_source[0])
+    {
+        LIST_FOR_EACH_ENTRY(dev, &g_capture_devices, struct pw_phys_device, entry)
+            if (!strcmp(dev->pw_name, g_default_source)) { def_src = dev; break; }
+    }
+    if ((def = malloc(offsetof(struct pw_phys_device, pw_name) + 1)))
+    {
+        def->pw_name[0] = '\0';
+        def->display = utf8_to_wstr("PipeWire");
+        def->form = Microphone;
+        def->def_period = 100000;
+        def->min_period = 50000;
+        if (def_src)
+        {
+            def->fmt = def_src->fmt;
+            def->channel_mask = def_src->channel_mask;
+        }
+        else
+        {
+            build_format(&def->fmt, rate, 2, SPEAKER_FRONT_LEFT | SPEAKER_FRONT_RIGHT);
+            def->channel_mask = def->fmt.dwChannelMask;
+        }
+        list_add_head(&g_capture_devices, &def->entry);
+    }
+}
+
+static void probe_teardown(struct probe *p)
+{
+    struct probe_node *pn;
+
+    LIST_FOR_EACH_ENTRY(pn, &p->nodes, struct probe_node, entry)
+    {
+        if (pn->proxy)
+        {
+            spa_hook_remove(&pn->listener);
+            pw_proxy_destroy((struct pw_proxy *)pn->proxy);
+            pn->proxy = NULL;
+        }
+    }
+    if (p->meta_default)
+    {
+        spa_hook_remove(&p->meta_default_listener);
+        pw_proxy_destroy((struct pw_proxy *)p->meta_default);
+        p->meta_default = NULL;
+    }
+    if (p->meta_settings)
+    {
+        spa_hook_remove(&p->meta_settings_listener);
+        pw_proxy_destroy((struct pw_proxy *)p->meta_settings);
+        p->meta_settings = NULL;
+    }
+    if (p->registry)
+    {
+        spa_hook_remove(&p->registry_listener);
+        pw_proxy_destroy((struct pw_proxy *)p->registry);
+        p->registry = NULL;
+    }
+    if (p->core)
+    {
+        spa_hook_remove(&p->core_listener);
+        pw_core_disconnect(p->core);
+        p->core = NULL;
+    }
+}
+
+static NTSTATUS pipewire_test_connect(void *args)
+{
+    struct test_connect_params *params = args;
+    struct probe p;
+    struct probe_node *pn, *next;
+    char *name;
+
+    free_device_lists();
+    list_init(&g_render_devices);
+    list_init(&g_capture_devices);
+    g_default_sink[0] = g_default_source[0] = '\0';
+
+    params->priority = Priority_Unavailable;
+
+    memset(&p, 0, sizeof(p));
+    list_init(&p.nodes);
+
+    if (!(p.loop = pw_thread_loop_new("winepipewire-probe", NULL)))
+    {
+        ERR("Failed to create PipeWire probe loop\n");
+        return STATUS_SUCCESS;
+    }
+    if (!(p.context = pw_context_new(pw_thread_loop_get_loop(p.loop), NULL, 0)))
+    {
+        ERR("Failed to create PipeWire probe context\n");
+        pw_thread_loop_destroy(p.loop);
+        return STATUS_SUCCESS;
+    }
+
+    pw_thread_loop_start(p.loop);
+    pw_thread_loop_lock(p.loop);
+
+    if (!(p.core = pw_context_connect(p.context, NULL, 0)))
+    {
+        pw_thread_loop_unlock(p.loop);
+        pw_thread_loop_stop(p.loop);
+        pw_context_destroy(p.context);
+        pw_thread_loop_destroy(p.loop);
+        return STATUS_SUCCESS;
+    }
+
+    pw_core_add_listener(p.core, &p.core_listener, &probe_core_events, &p);
+    p.registry = pw_core_get_registry(p.core, PW_VERSION_REGISTRY, 0);
+    if (p.registry)
+        pw_registry_add_listener(p.registry, &p.registry_listener, &probe_registry_events, &p);
+
+    /* First round-trip: globals emitted, nodes/metadata bound, enum_params
+     * issued.  Second: the param events and metadata properties land. */
+    probe_roundtrip(&p);
+    probe_roundtrip(&p);
+
+    probe_teardown(&p);
+    pw_thread_loop_unlock(p.loop);
+    pw_thread_loop_stop(p.loop);
+    pw_context_destroy(p.context);
+    pw_thread_loop_destroy(p.loop);
+
+    /* The pw loop is fully stopped: safe to do Wine string conversion. */
+    build_device_cache(&p);
+
+    LIST_FOR_EACH_ENTRY_SAFE(pn, next, &p.nodes, struct probe_node, entry)
+    {
+        list_remove(&pn->entry);
+        free(pn->node_name);
+        free(pn->display);
+        free(pn);
+    }
+
+    name = wstr_to_str(params->name);
+    TRACE("probe for %s: %u sinks default=%s, %u sources default=%s, rate=%u\n",
+          debugstr_a(name), list_count(&g_render_devices), debugstr_a(g_default_sink),
+          list_count(&g_capture_devices), debugstr_a(g_default_source), p.clock_rate);
+    free(name);
+
+    params->priority = Priority_Preferred;
+    return STATUS_SUCCESS;
+}
+
+/* ----------------------------------------------------------------------
+ * Endpoint enumeration / formats / periods / props
+ * ---------------------------------------------------------------------- */
+
+static NTSTATUS pipewire_get_endpoint_ids(void *args)
+{
+    struct get_endpoint_ids_params *params = args;
+    struct list *list = (params->flow == eRender) ? &g_render_devices : &g_capture_devices;
+    struct endpoint *endpoint = params->endpoints;
+    size_t len, name_len, needed;
+    unsigned int offset;
+    struct pw_phys_device *dev;
+
+    params->num = list_count(list);
+    offset = needed = params->num * sizeof(*params->endpoints);
+
+    LIST_FOR_EACH_ENTRY(dev, list, struct pw_phys_device, entry)
+    {
+        name_len = lstrlenW(dev->display) + 1;
+        len = strlen(dev->pw_name) + 1;
+        needed += name_len * sizeof(WCHAR) + ((len + 1) & ~1);
+
+        if (needed <= params->size)
+        {
+            endpoint->name = offset;
+            memcpy((char *)params->endpoints + offset, dev->display, name_len * sizeof(WCHAR));
+            offset += name_len * sizeof(WCHAR);
+            endpoint->device = offset;
+            memcpy((char *)params->endpoints + offset, dev->pw_name, len);
+            offset += (len + 1) & ~1;
+            endpoint++;
+        }
+    }
+    params->default_idx = 0;
+
+    if (needed > params->size)
+    {
+        params->size = needed;
+        params->result = HRESULT_FROM_WIN32(ERROR_INSUFFICIENT_BUFFER);
+    }
+    else
+        params->result = S_OK;
+    return STATUS_SUCCESS;
+}
+
+/* Resolve a device string to its cache entry.  A loopback capture targets a
+ * render sink, so an eCapture lookup that misses the capture list falls back
+ * to the render list (the sink's format/period describe the loopback). */
+static struct pw_phys_device *find_device(EDataFlow flow, const char *name)
+{
+    struct list *list = (flow == eRender) ? &g_render_devices : &g_capture_devices;
+    struct pw_phys_device *dev;
+
+    LIST_FOR_EACH_ENTRY(dev, list, struct pw_phys_device, entry)
+        if (!strcmp(name, dev->pw_name))
+            return dev;
+    if (flow == eCapture)
+    {
+        LIST_FOR_EACH_ENTRY(dev, &g_render_devices, struct pw_phys_device, entry)
+            if (!strcmp(name, dev->pw_name))
+                return dev;
+    }
+    return NULL;
+}
+
+static NTSTATUS pipewire_get_mix_format(void *args)
+{
+    struct get_mix_format_params *params = args;
+    struct pw_phys_device *dev = find_device(params->flow, params->device);
+
+    if (dev)
+    {
+        *params->fmt = dev->fmt;
+        params->result = S_OK;
+    }
+    else
+        params->result = E_FAIL;
+    return STATUS_SUCCESS;
+}
+
+static HRESULT get_device_period_helper(EDataFlow flow, const char *pw_name,
+                                        REFERENCE_TIME *def, REFERENCE_TIME *min)
+{
+    struct pw_phys_device *dev;
+
+    if (!def && !min)
+        return E_POINTER;
+
+    if (!(dev = find_device(flow, pw_name)))
+        return E_FAIL;
+    if (def)
+        *def = dev->def_period;
+    if (min)
+        *min = dev->min_period;
+    return S_OK;
+}
+
+static NTSTATUS pipewire_get_device_period(void *args)
+{
+    struct get_device_period_params *params = args;
+
+    params->result = get_device_period_helper(params->flow, params->device,
+                                               params->def_period, params->min_period);
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_is_format_supported(void *args)
+{
+    struct is_format_supported_params *params = args;
+
+    /* Shared-mode format conversion/resampling is the adapter's job, so we
+     * accept any format here (mirrors winepulse).  Exclusive mode is not
+     * supported. */
+    if (params->share == AUDCLNT_SHAREMODE_EXCLUSIVE)
+        params->result = AUDCLNT_E_EXCLUSIVE_MODE_NOT_ALLOWED;
+    else
+        params->result = S_OK;
+
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_get_prop_value(void *args)
+{
+    static const GUID PKEY_AudioEndpoint_GUID = {
+        0x1da5d803, 0xd492, 0x4edd, {0x8c, 0x23, 0xe0, 0xc0, 0xff, 0xee, 0x7f, 0x0e}
+    };
+    static const PROPERTYKEY devicepath_key = {
+        {0xb3f8fa53, 0x0004, 0x438e, {0x90, 0x03, 0x51, 0xa4, 0x6e, 0x13, 0x9b, 0xfc}}, 2
+    };
+    struct get_prop_value_params *params = args;
+    struct pw_phys_device *dev = find_device(params->flow, params->device);
+
+    if (!dev)
+    {
+        params->result = E_FAIL;
+        return STATUS_SUCCESS;
+    }
+    if (IsEqualPropertyKey(*params->prop, devicepath_key))
+    {
+        /* PipeWire nodes do not reliably carry vendor/product ids. */
+        params->result = E_NOTIMPL;
+        return STATUS_SUCCESS;
+    }
+    if (IsEqualGUID(&params->prop->fmtid, &PKEY_AudioEndpoint_GUID))
+    {
+        switch (params->prop->pid)
+        {
+        case 0:   /* FormFactor */
+            params->value->vt = VT_UI4;
+            params->value->ulVal = dev->form;
+            params->result = S_OK;
+            return STATUS_SUCCESS;
+        case 3:   /* PhysicalSpeakers */
+            if (dev->channel_mask)
+            {
+                params->value->vt = VT_UI4;
+                params->value->ulVal = dev->channel_mask;
+                params->result = S_OK;
+            }
+            else
+                params->result = E_FAIL;
+            return STATUS_SUCCESS;
+        }
+    }
+    params->result = E_NOTIMPL;
+    return STATUS_SUCCESS;
+}
+
+/* ----------------------------------------------------------------------
+ * Format mapping (pulse_spec_from_waveformat transplant)
+ * ---------------------------------------------------------------------- */
+
+static HRESULT pipewire_info_from_waveformat(struct pipewire_stream *stream, const WAVEFORMATEX *fmt)
+{
+    struct spa_audio_info_raw *info = &stream->info;
+    enum spa_audio_format spafmt = SPA_AUDIO_FORMAT_UNKNOWN;
+    UINT mask = 0, i = 0, j;
+
+    memset(info, 0, sizeof(*info));
+    info->rate = fmt->nSamplesPerSec;
+
+    switch (fmt->wFormatTag)
+    {
+    case WAVE_FORMAT_IEEE_FLOAT:
+        if (!fmt->nChannels || fmt->nChannels > 2 || fmt->wBitsPerSample != 32)
+            break;
+        spafmt = SPA_AUDIO_FORMAT_F32_LE;
+        info->channels = fmt->nChannels;
+        mask = get_channel_mask(fmt->nChannels);
+        break;
+    case WAVE_FORMAT_PCM:
+        if (!fmt->nChannels || fmt->nChannels > 2)
+            break;
+        if (fmt->wBitsPerSample == 8)
+            spafmt = SPA_AUDIO_FORMAT_U8;
+        else if (fmt->wBitsPerSample == 16)
+            spafmt = SPA_AUDIO_FORMAT_S16_LE;
+        else if (fmt->wBitsPerSample == 24)
+            spafmt = SPA_AUDIO_FORMAT_S24_LE;
+        else if (fmt->wBitsPerSample == 32)
+            spafmt = SPA_AUDIO_FORMAT_S32_LE;
+        else
+            return AUDCLNT_E_UNSUPPORTED_FORMAT;
+        info->channels = fmt->nChannels;
+        mask = get_channel_mask(fmt->nChannels);
+        break;
+    case WAVE_FORMAT_EXTENSIBLE:
+    {
+        WAVEFORMATEXTENSIBLE *wfe = (WAVEFORMATEXTENSIBLE *)fmt;
+        if (fmt->cbSize < sizeof(*wfe) - sizeof(*fmt))
+            break;
+        mask = wfe->dwChannelMask;
+        if (IsEqualGUID(&wfe->SubFormat, &KSDATAFORMAT_SUBTYPE_IEEE_FLOAT) &&
+            (!wfe->Samples.wValidBitsPerSample || wfe->Samples.wValidBitsPerSample == 32) &&
+            fmt->wBitsPerSample == 32)
+            spafmt = SPA_AUDIO_FORMAT_F32_LE;
+        else if (IsEqualGUID(&wfe->SubFormat, &KSDATAFORMAT_SUBTYPE_PCM))
+        {
+            DWORD valid = wfe->Samples.wValidBitsPerSample;
+            if (!valid)
+                valid = fmt->wBitsPerSample;
+            if (!valid || valid > fmt->wBitsPerSample)
+                break;
+            switch (fmt->wBitsPerSample)
+            {
+            case 8:  if (valid == 8) spafmt = SPA_AUDIO_FORMAT_U8; break;
+            case 16: if (valid == 16) spafmt = SPA_AUDIO_FORMAT_S16_LE; break;
+            case 24: if (valid == 24) spafmt = SPA_AUDIO_FORMAT_S24_LE; break;
+            case 32:
+                if (valid == 32) spafmt = SPA_AUDIO_FORMAT_S32_LE;
+                else if (valid == 24) spafmt = SPA_AUDIO_FORMAT_S24_32_LE;
+                break;
+            default:
+                return AUDCLNT_E_UNSUPPORTED_FORMAT;
+            }
+        }
+        info->channels = fmt->nChannels;
+        if (!mask || (mask & (SPEAKER_ALL | SPEAKER_RESERVED)))
+            mask = get_channel_mask(fmt->nChannels);
+        for (j = 0; j < ARRAY_SIZE(spa_pos_from_wfx) && i < fmt->nChannels; ++j)
+            if (mask & (1u << j))
+                info->position[i++] = spa_pos_from_wfx[j];
+        if (mask == SPEAKER_FRONT_CENTER)
+            info->position[0] = SPA_AUDIO_CHANNEL_MONO;
+        if (i < fmt->nChannels || (mask & SPEAKER_RESERVED))
+        {
+            ERR("Invalid channel mask: %u/%u and %#x\n", i, fmt->nChannels, mask);
+            spafmt = SPA_AUDIO_FORMAT_UNKNOWN;
+        }
+        if (spafmt == SPA_AUDIO_FORMAT_UNKNOWN)
+            return AUDCLNT_E_UNSUPPORTED_FORMAT;
+        info->format = spafmt;
+        return S_OK;
+    }
+    default:
+        WARN("Unhandled tag %x\n", fmt->wFormatTag);
+        return AUDCLNT_E_UNSUPPORTED_FORMAT;
+    }
+
+    if (spafmt == SPA_AUDIO_FORMAT_UNKNOWN || !info->channels)
+        return AUDCLNT_E_UNSUPPORTED_FORMAT;
+    info->format = spafmt;
+    for (j = 0; j < ARRAY_SIZE(spa_pos_from_wfx) && i < info->channels; ++j)
+        if (mask & (1u << j))
+            info->position[i++] = spa_pos_from_wfx[j];
+    if (mask == SPEAKER_FRONT_CENTER)
+        info->position[0] = SPA_AUDIO_CHANNEL_MONO;
+    return S_OK;
+}
+
+/* ----------------------------------------------------------------------
+ * pw_stream callbacks (foreign thread, loop lock held: no ntdll/TRACE)
+ * ---------------------------------------------------------------------- */
+
+static void apply_volume(const struct pipewire_stream *stream, BYTE *buffer, UINT32 bytes)
+{
+    const float *vol = stream->vol;
+    UINT32 i, channels = stream->info.channels, mute = 0;
+    BOOL adjust = FALSE;
+    BYTE *end;
+
+    if (!bytes)
+        return;
+
+    for (i = 0; i < channels; i++)
+    {
+        adjust |= vol[i] != 1.0f;
+        if (vol[i] == 0.0f)
+            mute++;
+    }
+    if (mute == channels)
+    {
+        silence_buffer(stream->info.format, buffer, bytes);
+        return;
+    }
+    if (!adjust)
+        return;
+
+    end = buffer + bytes;
+    switch (stream->info.format)
+    {
+#ifndef WORDS_BIGENDIAN
+#define PROCESS_BUFFER(type) do         \
+{                                       \
+    type *p = (type *)buffer;           \
+    do                                  \
+    {                                   \
+        for (i = 0; i < channels; i++)  \
+            p[i] = p[i] * vol[i];       \
+        p += i;                         \
+    } while ((BYTE *)p != end);         \
+} while (0)
+    case SPA_AUDIO_FORMAT_S16_LE:
+        PROCESS_BUFFER(INT16);
+        break;
+    case SPA_AUDIO_FORMAT_S32_LE:
+        PROCESS_BUFFER(INT32);
+        break;
+    case SPA_AUDIO_FORMAT_F32_LE:
+        PROCESS_BUFFER(float);
+        break;
+#undef PROCESS_BUFFER
+    case SPA_AUDIO_FORMAT_S24_32_LE:
+    {
+        UINT32 *p = (UINT32 *)buffer;
+        do
+        {
+            for (i = 0; i < channels; i++)
+            {
+                p[i] = (INT32)((INT32)(p[i] << 8) * vol[i]);
+                p[i] >>= 8;
+            }
+            p += i;
+        } while ((BYTE *)p != end);
+        break;
+    }
+    case SPA_AUDIO_FORMAT_S24_LE:
+    {
+        UINT32 *q = (UINT32 *)buffer;
+        BYTE *p;
+
+        i = 0;
+        while (end - (BYTE *)q >= 12)
+        {
+            UINT32 v[4], k;
+            v[0] = q[0] << 8;
+            v[1] = q[1] << 16 | (q[0] >> 16 & ~0xff);
+            v[2] = q[2] << 24 | (q[1] >> 8  & ~0xff);
+            v[3] = q[2] & ~0xff;
+            for (k = 0; k < 4; k++)
+            {
+                v[k] = (INT32)((INT32)v[k] * vol[i]);
+                if (++i == channels) i = 0;
+            }
+            *q++ = v[0] >> 8  | (v[1] & ~0xff) << 16;
+            *q++ = v[1] >> 16 | (v[2] & ~0xff) << 8;
+            *q++ = v[2] >> 24 | (v[3] & ~0xff);
+        }
+        p = (BYTE *)q;
+        while (p != end)
+        {
+            UINT32 v = (INT32)((INT32)(p[0] << 8 | p[1] << 16 | p[2] << 24) * vol[i]);
+            *p++ = v >> 8  & 0xff;
+            *p++ = v >> 16 & 0xff;
+            *p++ = v >> 24;
+            if (++i == channels) i = 0;
+        }
+        break;
+    }
+#endif
+    case SPA_AUDIO_FORMAT_U8:
+    {
+        UINT8 *p = (UINT8 *)buffer;
+        do
+        {
+            for (i = 0; i < channels; i++)
+                p[i] = (int)((p[i] - 128) * vol[i]) + 128;
+            p += i;
+        } while ((BYTE *)p != end);
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+static void on_stream_state_changed(void *data, enum pw_stream_state old,
+                                    enum pw_stream_state state, const char *error)
+{
+    if (pw_loop_global)
+        pw_thread_loop_signal(pw_loop_global, false);
+}
+
+static void on_stream_process(void *data)
+{
+    struct pipewire_stream *stream = data;
+    struct pw_buffer *b;
+    struct spa_buffer *buf;
+    struct spa_data *d;
+
+    if (!(b = pw_stream_dequeue_buffer(stream->pw)))
+        return;
+    buf = b->buffer;
+    if (!buf->n_datas || !(d = &buf->datas[0])->data)
+    {
+        pw_stream_queue_buffer(stream->pw, b);
+        return;
+    }
+
+    if (stream->dataflow == eRender)
+    {
+        UINT32 maxsize = d->maxsize;
+        UINT32 req_frames, need_bytes, n;
+
+        req_frames = b->requested ? (UINT32)b->requested : maxsize / stream->frame_size;
+        if (req_frames * stream->frame_size > maxsize)
+            req_frames = maxsize / stream->frame_size;
+        need_bytes = req_frames * stream->frame_size;
+
+        if (stream->started)
+        {
+            n = min(need_bytes, stream->pa_held_bytes);
+            copy_from_ring(d->data, stream->local_buffer, stream->real_bufsize_bytes,
+                           stream->pa_offs_bytes, n);
+            apply_volume(stream, d->data, n);
+            if (n < need_bytes)
+            {
+                silence_buffer(stream->info.format, (BYTE *)d->data + n, need_bytes - n);
+                stream->just_underran = TRUE;
+            }
+            stream->pa_offs_bytes = (stream->pa_offs_bytes + n) % stream->real_bufsize_bytes;
+            stream->pa_held_bytes -= n;
+        }
+        else
+            silence_buffer(stream->info.format, d->data, need_bytes);
+
+        d->chunk->offset = 0;
+        d->chunk->stride = stream->frame_size;
+        d->chunk->size = need_bytes;
+        b->size = req_frames;
+    }
+    else /* eCapture */
+    {
+        if (stream->started && stream->capture_ring)
+        {
+            UINT32 avail = d->chunk->size;
+            const BYTE *src = (const BYTE *)d->data + d->chunk->offset;
+            SIZE_T n = avail;
+
+            if (n > stream->capture_ring_size)
+            {
+                src += n - stream->capture_ring_size;
+                n = stream->capture_ring_size;
+            }
+            if (stream->cap_held_bytes + n > stream->capture_ring_size)
+            {
+                SIZE_T drop = stream->cap_held_bytes + n - stream->capture_ring_size;
+                stream->cap_read_offs = (stream->cap_read_offs + drop) % stream->capture_ring_size;
+                stream->cap_held_bytes -= drop;
+            }
+            if (n)
+            {
+                SIZE_T woff = (stream->cap_read_offs + stream->cap_held_bytes) % stream->capture_ring_size;
+                SIZE_T first = min(n, stream->capture_ring_size - woff);
+                memcpy(stream->capture_ring + woff, src, first);
+                if (n > first)
+                    memcpy(stream->capture_ring, src + first, n - first);
+                stream->cap_held_bytes += n;
+            }
+        }
+    }
+
+    pw_stream_queue_buffer(stream->pw, b);
+}
+
+static const struct pw_stream_events stream_events = {
+    PW_VERSION_STREAM_EVENTS,
+    .state_changed = on_stream_state_changed,
+    .process = on_stream_process,
+};
+
+/* ----------------------------------------------------------------------
+ * Stream creation / release
+ * ---------------------------------------------------------------------- */
+
+static BOOL stream_valid(struct pipewire_stream *stream)
+{
+    enum pw_stream_state st;
+    if (!stream || !stream->pw)
+        return FALSE;
+    st = pw_stream_get_state(stream->pw, NULL);
+    return st == PW_STREAM_STATE_PAUSED || st == PW_STREAM_STATE_STREAMING;
+}
+
+static BOOL device_is_sink(const char *device)
+{
+    struct pw_phys_device *dev;
+    LIST_FOR_EACH_ENTRY(dev, &g_render_devices, struct pw_phys_device, entry)
+        if (!strcmp(device, dev->pw_name))
+            return TRUE;
+    return FALSE;
+}
+
+/* Called with the loop lock held. */
+static HRESULT pipewire_stream_connect(struct pipewire_stream *stream, const char *device,
+                                       const WCHAR *appname)
+{
+    struct pw_properties *props;
+    uint8_t buffer[1024];
+    struct spa_pod_builder b = SPA_POD_BUILDER_INIT(buffer, sizeof(buffer));
+    const struct spa_pod *params[1];
+    uint32_t period_frames = stream->period_bytes / stream->frame_size;
+    enum pw_stream_state st;
+    char *app;
+    int tries;
+
+    props = pw_properties_new(PW_KEY_MEDIA_TYPE, "Audio",
+                              PW_KEY_MEDIA_CATEGORY,
+                              stream->dataflow == eRender ? "Playback" : "Capture",
+                              NULL);
+    if (!props)
+        return AUDCLNT_E_ENDPOINT_CREATE_FAILED;
+
+    if (appname && (app = wstr_to_str(appname)))
+    {
+        pw_properties_set(props, PW_KEY_APP_NAME, app);
+        free(app);
+    }
+    pw_properties_setf(props, PW_KEY_NODE_LATENCY, "%u/%u", period_frames, stream->info.rate);
+    if (device && device[0])
+    {
+        pw_properties_set(props, PW_KEY_TARGET_OBJECT, device);
+        if (stream->dataflow == eCapture && device_is_sink(device))
+            pw_properties_set(props, PW_KEY_STREAM_CAPTURE_SINK, "true");
+    }
+
+    stream->pw = pw_stream_new(pw_core_global, "winepipewire", props);
+    if (!stream->pw)
+        return AUDCLNT_E_ENDPOINT_CREATE_FAILED;
+
+    pw_stream_add_listener(stream->pw, &stream->stream_listener, &stream_events, stream);
+
+    params[0] = spa_format_audio_raw_build(&b, SPA_PARAM_EnumFormat, &stream->info);
+
+    if (pw_stream_connect(stream->pw,
+                          stream->dataflow == eRender ? PW_DIRECTION_OUTPUT : PW_DIRECTION_INPUT,
+                          PW_ID_ANY,
+                          PW_STREAM_FLAG_AUTOCONNECT | PW_STREAM_FLAG_MAP_BUFFERS |
+                          PW_STREAM_FLAG_INACTIVE,
+                          params, 1) < 0)
+        return AUDCLNT_E_ENDPOINT_CREATE_FAILED;
+
+    for (tries = 0; tries < 10; tries++)
+    {
+        st = pw_stream_get_state(stream->pw, NULL);
+        if (st == PW_STREAM_STATE_PAUSED || st == PW_STREAM_STATE_STREAMING)
+            return S_OK;
+        if (st == PW_STREAM_STATE_ERROR || st == PW_STREAM_STATE_UNCONNECTED)
+            return AUDCLNT_E_ENDPOINT_CREATE_FAILED;
+        if (pw_thread_loop_timed_wait(pw_loop_global, 1) != 0)
+            break;
+    }
+    st = pw_stream_get_state(stream->pw, NULL);
+    if (st == PW_STREAM_STATE_PAUSED || st == PW_STREAM_STATE_STREAMING)
+        return S_OK;
+    return AUDCLNT_E_ENDPOINT_CREATE_FAILED;
+}
+
+static NTSTATUS pipewire_create_stream(void *args)
+{
+    struct create_stream_params *params = args;
+    struct pipewire_stream *stream;
+    SIZE_T bufsize_bytes, size;
+    UINT32 i;
+    HRESULT hr;
+
+    if (params->share == AUDCLNT_SHAREMODE_EXCLUSIVE)
+    {
+        params->result = AUDCLNT_E_EXCLUSIVE_MODE_NOT_ALLOWED;
+        return STATUS_SUCCESS;
+    }
+
+    pw_thread_loop_lock(pw_loop_global);
+
+    if (FAILED(hr = pipewire_connect()))
+    {
+        params->result = hr;
+        pw_thread_loop_unlock(pw_loop_global);
+        return STATUS_SUCCESS;
+    }
+
+    if (!(stream = calloc(1, sizeof(*stream))))
+    {
+        params->result = E_OUTOFMEMORY;
+        pw_thread_loop_unlock(pw_loop_global);
+        return STATUS_SUCCESS;
+    }
+
+    stream->dataflow = params->flow;
+    for (i = 0; i < ARRAY_SIZE(stream->vol); ++i)
+        stream->vol[i] = 1.f;
+
+    hr = pipewire_info_from_waveformat(stream, params->fmt);
+    TRACE("Obtaining format returns %08x\n", (unsigned)hr);
+    if (FAILED(hr))
+        goto exit;
+
+    stream->frame_size = spa_format_bytes(stream->info.format) * stream->info.channels;
+    if (!stream->frame_size)
+    {
+        hr = AUDCLNT_E_UNSUPPORTED_FORMAT;
+        goto exit;
+    }
+
+    stream->def_period = params->period;
+    stream->duration = params->duration;
+    stream->flags = params->flags;
+    stream->share = params->share;
+    stream->mmdev_period_usec = params->period / 10;
+
+    stream->period_bytes = stream->frame_size * muldiv(params->period, stream->info.rate, 10000000);
+    if (stream->period_bytes == 0)
+    {
+        hr = E_INVALIDARG;
+        goto exit;
+    }
+
+    stream->bufsize_frames =
+        (SIZE_T)(((UINT64)params->duration * stream->info.rate + 9999999) / 10000000);
+    bufsize_bytes = stream->bufsize_frames * stream->frame_size;
+
+    hr = pipewire_stream_connect(stream, params->device, params->name);
+    if (FAILED(hr))
+        goto exit;
+
+    if (stream->dataflow == eRender)
+    {
+        size = stream->real_bufsize_bytes = stream->bufsize_frames * 2 * stream->frame_size;
+        if (NtAllocateVirtualMemory(GetCurrentProcess(), (void **)&stream->local_buffer,
+                                    0, &size, MEM_COMMIT, PAGE_READWRITE))
+            hr = E_OUTOFMEMORY;
+    }
+    else
+    {
+        UINT32 capture_packets, unalign;
+
+        if ((unalign = bufsize_bytes % stream->period_bytes))
+            bufsize_bytes += stream->period_bytes - unalign;
+        stream->bufsize_frames = bufsize_bytes / stream->frame_size;
+        stream->real_bufsize_bytes = bufsize_bytes;
+        capture_packets = stream->real_bufsize_bytes / stream->period_bytes;
+
+        size = stream->real_bufsize_bytes + capture_packets * sizeof(ACPacket);
+        if (NtAllocateVirtualMemory(GetCurrentProcess(), (void **)&stream->local_buffer,
+                                    0, &size, MEM_COMMIT, PAGE_READWRITE))
+            hr = E_OUTOFMEMORY;
+        else
+        {
+            ACPacket *cur_packet = (ACPacket *)((char *)stream->local_buffer + stream->real_bufsize_bytes);
+            BYTE *data = stream->local_buffer;
+            silence_buffer(stream->info.format, stream->local_buffer, stream->real_bufsize_bytes);
+            list_init(&stream->packet_free_head);
+            list_init(&stream->packet_filled_head);
+            for (i = 0; i < capture_packets; ++i, ++cur_packet)
+            {
+                list_add_tail(&stream->packet_free_head, &cur_packet->entry);
+                cur_packet->data = data;
+                data += stream->period_bytes;
+            }
+
+            /* staging ring fed by the process callback */
+            size = stream->capture_ring_size = stream->real_bufsize_bytes;
+            if (NtAllocateVirtualMemory(GetCurrentProcess(), (void **)&stream->capture_ring,
+                                        0, &size, MEM_COMMIT, PAGE_READWRITE))
+                hr = E_OUTOFMEMORY;
+        }
+    }
+
+    *params->channel_count = stream->info.channels;
+    *params->stream = (stream_handle)(UINT_PTR)stream;
+
+exit:
+    if (FAILED(params->result = hr))
+    {
+        if (stream->pw)
+        {
+            pw_stream_destroy(stream->pw);
+            stream->pw = NULL;
+        }
+        if (stream->local_buffer)
+        {
+            size = 0;
+            NtFreeVirtualMemory(GetCurrentProcess(), (void **)&stream->local_buffer, &size, MEM_RELEASE);
+        }
+        if (stream->capture_ring)
+        {
+            size = 0;
+            NtFreeVirtualMemory(GetCurrentProcess(), (void **)&stream->capture_ring, &size, MEM_RELEASE);
+        }
+        free(stream);
+    }
+
+    pw_thread_loop_unlock(pw_loop_global);
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_release_stream(void *args)
+{
+    struct release_stream_params *params = args;
+    struct pipewire_stream *stream = handle_get_stream(params->stream);
+    SIZE_T size;
+
+    if (stream->timer_thread)
+    {
+        stream->please_quit = TRUE;
+        NtWaitForSingleObject(stream->timer_thread, FALSE, NULL);
+        NtClose(stream->timer_thread);
+    }
+
+    pw_thread_loop_lock(pw_loop_global);
+    if (stream->pw)
+    {
+        pw_stream_destroy(stream->pw);
+        stream->pw = NULL;
+    }
+    pw_thread_loop_unlock(pw_loop_global);
+
+    if (stream->tmp_buffer)
+    {
+        size = 0;
+        NtFreeVirtualMemory(GetCurrentProcess(), (void **)&stream->tmp_buffer, &size, MEM_RELEASE);
+    }
+    if (stream->local_buffer)
+    {
+        size = 0;
+        NtFreeVirtualMemory(GetCurrentProcess(), (void **)&stream->local_buffer, &size, MEM_RELEASE);
+    }
+    if (stream->capture_ring)
+    {
+        size = 0;
+        NtFreeVirtualMemory(GetCurrentProcess(), (void **)&stream->capture_ring, &size, MEM_RELEASE);
+    }
+    free(stream);
+    params->result = S_OK;
+    return STATUS_SUCCESS;
+}
+
+/* ----------------------------------------------------------------------
+ * Capture slicing + timer thread (pulse_read / pulse_timer_loop transplant)
+ * ---------------------------------------------------------------------- */
+
+/* Slice period-sized packets out of the staging ring.  Runs on the Wine
+ * timer thread with the loop lock held: ntdll (QPC) is legal here. */
+static void pipewire_read(struct pipewire_stream *stream)
+{
+    while (stream->cap_held_bytes >= stream->period_bytes)
+    {
+        ACPacket *p, *next;
+        LARGE_INTEGER stamp, freq;
+
+        if (!(p = (ACPacket *)list_head(&stream->packet_free_head)))
+        {
+            p = (ACPacket *)list_head(&stream->packet_filled_head);
+            if (!p) return;
+            if (!p->discont)
+            {
+                next = (ACPacket *)p->entry.next;
+                next->discont = 1;
+            }
+            else
+                p = (ACPacket *)list_tail(&stream->packet_filled_head);
+        }
+        else
+        {
+            stream->held_bytes += stream->period_bytes;
+        }
+        NtQueryPerformanceCounter(&stamp, &freq);
+        p->qpcpos = (stamp.QuadPart * (INT64)10000000) / freq.QuadPart;
+        p->discont = 0;
+        list_remove(&p->entry);
+        list_add_tail(&stream->packet_filled_head, &p->entry);
+
+        copy_from_ring(p->data, stream->capture_ring, stream->capture_ring_size,
+                       stream->cap_read_offs, stream->period_bytes);
+        stream->cap_read_offs = (stream->cap_read_offs + stream->period_bytes) % stream->capture_ring_size;
+        stream->cap_held_bytes -= stream->period_bytes;
+    }
+}
+
+static void pipewire_timer_loop(void *args)
+{
+    struct pipewire_stream *stream = args;
+    LARGE_INTEGER delay;
+    UINT64 last_time = 0, now;
+    struct pw_time pwt;
+
+    pw_thread_loop_lock(pw_loop_global);
+    delay.QuadPart = -(INT64)stream->mmdev_period_usec * 10;
+    if (stream->pw && pw_stream_get_time_n(stream->pw, &pwt, sizeof(pwt)) == 0 && pwt.now)
+        last_time = (UINT64)pwt.now / 1000;
+    pw_thread_loop_unlock(pw_loop_global);
+
+    while (!stream->please_quit)
+    {
+        int have_now = 0;
+
+        NtDelayExecution(FALSE, &delay);
+
+        pw_thread_loop_lock(pw_loop_global);
+        delay.QuadPart = -(INT64)stream->mmdev_period_usec * 10;
+
+        if (stream->pw && pw_stream_get_time_n(stream->pw, &pwt, sizeof(pwt)) == 0 && pwt.now)
+        {
+            now = (UINT64)pwt.now / 1000;
+            have_now = 1;
+        }
+
+        if (have_now)
+        {
+            if (stream->started && (stream->dataflow == eCapture || stream->held_bytes))
+            {
+                if (stream->just_underran)
+                {
+                    last_time = now;
+                    stream->just_started = TRUE;
+                    stream->just_underran = FALSE;
+                }
+
+                if (stream->just_started)
+                {
+                    /* play out a period to absorb latency and get timing */
+                    if (now - last_time > stream->mmdev_period_usec)
+                    {
+                        stream->just_started = FALSE;
+                        last_time = now;
+                    }
+                }
+                else
+                {
+                    INT32 adjust = last_time + stream->mmdev_period_usec - now;
+
+                    if (adjust > (INT32)(stream->mmdev_period_usec / 2))
+                        adjust = stream->mmdev_period_usec / 2;
+                    else if (adjust < -(INT32)(stream->mmdev_period_usec / 2))
+                        adjust = -(INT32)(stream->mmdev_period_usec / 2);
+
+                    delay.QuadPart = -((INT64)stream->mmdev_period_usec + adjust) * 10;
+                    last_time += stream->mmdev_period_usec;
+                }
+
+                if (stream->dataflow == eRender)
+                {
+                    /* advance one period regardless of what the device does */
+                    UINT32 adv = min(stream->period_bytes, stream->held_bytes);
+                    stream->lcl_offs_bytes += adv;
+                    stream->lcl_offs_bytes %= stream->real_bufsize_bytes;
+                    stream->held_bytes -= adv;
+                }
+                else
+                {
+                    pipewire_read(stream);
+                }
+            }
+            else
+            {
+                last_time = now;
+                delay.QuadPart = -(INT64)stream->mmdev_period_usec * 10;
+            }
+        }
+
+        if (stream->event)
+            NtSetEvent(stream->event, NULL);
+
+        pw_thread_loop_unlock(pw_loop_global);
+    }
+    PsTerminateSystemThread(0);
+}
+
+static NTSTATUS pipewire_start(void *args)
+{
+    struct start_params *params = args;
+    struct pipewire_stream *stream = handle_get_stream(params->stream);
+    static const WCHAR name[] = {'w','i','n','e','p','i','p','e','w','i','r','e','_','t','i','m','e','r',0};
+
+    params->result = S_OK;
+    pw_thread_loop_lock(pw_loop_global);
+    if (!stream_valid(stream))
+    {
+        pw_thread_loop_unlock(pw_loop_global);
+        params->result = S_OK;
+        return STATUS_SUCCESS;
+    }
+
+    if ((stream->flags & AUDCLNT_STREAMFLAGS_EVENTCALLBACK) && !stream->event)
+    {
+        pw_thread_loop_unlock(pw_loop_global);
+        params->result = AUDCLNT_E_EVENTHANDLE_NOT_SET;
+        return STATUS_SUCCESS;
+    }
+
+    if (stream->started)
+    {
+        pw_thread_loop_unlock(pw_loop_global);
+        params->result = AUDCLNT_E_NOT_STOPPED;
+        return STATUS_SUCCESS;
+    }
+
+    pw_stream_set_active(stream->pw, true);
+    stream->started = TRUE;
+    stream->just_started = TRUE;
+    pw_thread_loop_unlock(pw_loop_global);
+
+    if (!stream->timer_thread)
+        create_unix_thread(&stream->timer_thread, name, pipewire_timer_loop, stream);
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_stop(void *args)
+{
+    struct stop_params *params = args;
+    struct pipewire_stream *stream = handle_get_stream(params->stream);
+
+    pw_thread_loop_lock(pw_loop_global);
+    if (!stream_valid(stream))
+    {
+        pw_thread_loop_unlock(pw_loop_global);
+        params->result = AUDCLNT_E_DEVICE_INVALIDATED;
+        return STATUS_SUCCESS;
+    }
+
+    if (!stream->started)
+    {
+        pw_thread_loop_unlock(pw_loop_global);
+        params->result = S_FALSE;
+        return STATUS_SUCCESS;
+    }
+
+    pw_stream_set_active(stream->pw, false);
+    stream->started = FALSE;
+    pw_thread_loop_unlock(pw_loop_global);
+    params->result = S_OK;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_reset(void *args)
+{
+    struct reset_params *params = args;
+    struct pipewire_stream *stream = handle_get_stream(params->stream);
+
+    pw_thread_loop_lock(pw_loop_global);
+    if (!stream_valid(stream))
+    {
+        pw_thread_loop_unlock(pw_loop_global);
+        params->result = AUDCLNT_E_DEVICE_INVALIDATED;
+        return STATUS_SUCCESS;
+    }
+
+    if (stream->started)
+    {
+        pw_thread_loop_unlock(pw_loop_global);
+        params->result = AUDCLNT_E_NOT_STOPPED;
+        return STATUS_SUCCESS;
+    }
+
+    if (stream->locked)
+    {
+        pw_thread_loop_unlock(pw_loop_global);
+        params->result = AUDCLNT_E_BUFFER_OPERATION_PENDING;
+        return STATUS_SUCCESS;
+    }
+
+    pw_stream_flush(stream->pw, false);
+
+    if (stream->dataflow == eRender)
+    {
+        stream->clock_lastpos = stream->clock_written = 0;
+        stream->pa_offs_bytes = stream->lcl_offs_bytes = 0;
+        stream->held_bytes = stream->pa_held_bytes = 0;
+    }
+    else
+    {
+        ACPacket *p;
+        stream->clock_written += stream->held_bytes;
+        stream->held_bytes = 0;
+        stream->cap_read_offs = stream->cap_held_bytes = 0;
+
+        if ((p = stream->locked_ptr))
+        {
+            stream->locked_ptr = NULL;
+            list_add_tail(&stream->packet_free_head, &p->entry);
+        }
+        list_move_tail(&stream->packet_free_head, &stream->packet_filled_head);
+    }
+    pw_thread_loop_unlock(pw_loop_global);
+    params->result = S_OK;
+    return STATUS_SUCCESS;
+}
+
+/* ----------------------------------------------------------------------
+ * Render / capture buffer transfer
+ * ---------------------------------------------------------------------- */
+
+static BOOL alloc_tmp_buffer(struct pipewire_stream *stream, SIZE_T bytes)
+{
+    SIZE_T size;
+
+    if (stream->tmp_buffer_bytes >= bytes)
+        return TRUE;
+
+    if (stream->tmp_buffer)
+    {
+        size = 0;
+        NtFreeVirtualMemory(GetCurrentProcess(), (void **)&stream->tmp_buffer, &size, MEM_RELEASE);
+        stream->tmp_buffer = NULL;
+        stream->tmp_buffer_bytes = 0;
+    }
+    if (NtAllocateVirtualMemory(GetCurrentProcess(), (void **)&stream->tmp_buffer,
+                                0, &bytes, MEM_COMMIT, PAGE_READWRITE))
+        return FALSE;
+
+    stream->tmp_buffer_bytes = bytes;
+    return TRUE;
+}
+
+static UINT32 pipewire_render_padding(struct pipewire_stream *stream)
+{
+    return stream->held_bytes / stream->frame_size;
+}
+
+static UINT32 pipewire_capture_padding(struct pipewire_stream *stream)
+{
+    ACPacket *packet = stream->locked_ptr;
+    if (!packet && !list_empty(&stream->packet_filled_head))
+    {
+        packet = (ACPacket *)list_head(&stream->packet_filled_head);
+        stream->locked_ptr = packet;
+        list_remove(&packet->entry);
+    }
+    return stream->held_bytes / stream->frame_size;
+}
+
+static NTSTATUS pipewire_get_render_buffer(void *args)
+{
+    struct get_render_buffer_params *params = args;
+    struct pipewire_stream *stream = handle_get_stream(params->stream);
+    size_t bytes;
+    UINT32 wri_offs_bytes;
+
+    pw_thread_loop_lock(pw_loop_global);
+    if (!stream_valid(stream))
+    {
+        pw_thread_loop_unlock(pw_loop_global);
+        params->result = AUDCLNT_E_DEVICE_INVALIDATED;
+        return STATUS_SUCCESS;
+    }
+
+    if (stream->locked)
+    {
+        pw_thread_loop_unlock(pw_loop_global);
+        params->result = AUDCLNT_E_OUT_OF_ORDER;
+        return STATUS_SUCCESS;
+    }
+
+    if (!params->frames)
+    {
+        pw_thread_loop_unlock(pw_loop_global);
+        *params->data = NULL;
+        params->result = S_OK;
+        return STATUS_SUCCESS;
+    }
+
+    if (stream->held_bytes / stream->frame_size + params->frames > stream->bufsize_frames)
+    {
+        pw_thread_loop_unlock(pw_loop_global);
+        params->result = AUDCLNT_E_BUFFER_TOO_LARGE;
+        return STATUS_SUCCESS;
+    }
+
+    bytes = params->frames * stream->frame_size;
+    wri_offs_bytes = (stream->lcl_offs_bytes + stream->held_bytes) % stream->real_bufsize_bytes;
+    if (wri_offs_bytes + bytes > stream->real_bufsize_bytes)
+    {
+        if (!alloc_tmp_buffer(stream, bytes))
+        {
+            pw_thread_loop_unlock(pw_loop_global);
+            params->result = E_OUTOFMEMORY;
+            return STATUS_SUCCESS;
+        }
+        *params->data = stream->tmp_buffer;
+        stream->locked = -bytes;
+    }
+    else
+    {
+        *params->data = stream->local_buffer + wri_offs_bytes;
+        stream->locked = bytes;
+    }
+
+    silence_buffer(stream->info.format, *params->data, bytes);
+
+    pw_thread_loop_unlock(pw_loop_global);
+    params->result = S_OK;
+    return STATUS_SUCCESS;
+}
+
+static void pipewire_wrap_buffer(struct pipewire_stream *stream, BYTE *buffer, UINT32 written_bytes)
+{
+    UINT32 wri_offs_bytes = (stream->lcl_offs_bytes + stream->held_bytes) % stream->real_bufsize_bytes;
+    UINT32 chunk_bytes = stream->real_bufsize_bytes - wri_offs_bytes;
+
+    if (written_bytes <= chunk_bytes)
+    {
+        memcpy(stream->local_buffer + wri_offs_bytes, buffer, written_bytes);
+    }
+    else
+    {
+        memcpy(stream->local_buffer + wri_offs_bytes, buffer, chunk_bytes);
+        memcpy(stream->local_buffer, buffer + chunk_bytes, written_bytes - chunk_bytes);
+    }
+}
+
+static NTSTATUS pipewire_release_render_buffer(void *args)
+{
+    struct release_render_buffer_params *params = args;
+    struct pipewire_stream *stream = handle_get_stream(params->stream);
+    UINT32 written_bytes;
+    BYTE *buffer;
+
+    pw_thread_loop_lock(pw_loop_global);
+    if (!stream->locked || !params->written_frames)
+    {
+        stream->locked = 0;
+        pw_thread_loop_unlock(pw_loop_global);
+        params->result = params->written_frames ? AUDCLNT_E_OUT_OF_ORDER : S_OK;
+        return STATUS_SUCCESS;
+    }
+
+    if (params->written_frames * stream->frame_size >
+        (stream->locked >= 0 ? stream->locked : -stream->locked))
+    {
+        pw_thread_loop_unlock(pw_loop_global);
+        params->result = AUDCLNT_E_INVALID_SIZE;
+        return STATUS_SUCCESS;
+    }
+
+    if (stream->locked >= 0)
+        buffer = stream->local_buffer + (stream->lcl_offs_bytes + stream->held_bytes) % stream->real_bufsize_bytes;
+    else
+        buffer = stream->tmp_buffer;
+
+    written_bytes = params->written_frames * stream->frame_size;
+    if (params->flags & AUDCLNT_BUFFERFLAGS_SILENT)
+        silence_buffer(stream->info.format, buffer, written_bytes);
+
+    if (stream->locked < 0)
+        pipewire_wrap_buffer(stream, buffer, written_bytes);
+
+    stream->held_bytes += written_bytes;
+    stream->pa_held_bytes += written_bytes;
+    if (stream->pa_held_bytes > stream->real_bufsize_bytes)
+    {
+        stream->pa_offs_bytes += stream->pa_held_bytes - stream->real_bufsize_bytes;
+        stream->pa_offs_bytes %= stream->real_bufsize_bytes;
+        stream->pa_held_bytes = stream->real_bufsize_bytes;
+    }
+    stream->clock_written += written_bytes;
+    stream->locked = 0;
+
+    pw_thread_loop_unlock(pw_loop_global);
+    params->result = S_OK;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_get_capture_buffer(void *args)
+{
+    struct get_capture_buffer_params *params = args;
+    struct pipewire_stream *stream = handle_get_stream(params->stream);
+    ACPacket *packet;
+
+    pw_thread_loop_lock(pw_loop_global);
+    if (!stream_valid(stream))
+    {
+        pw_thread_loop_unlock(pw_loop_global);
+        params->result = AUDCLNT_E_DEVICE_INVALIDATED;
+        return STATUS_SUCCESS;
+    }
+    if (stream->locked)
+    {
+        pw_thread_loop_unlock(pw_loop_global);
+        params->result = AUDCLNT_E_OUT_OF_ORDER;
+        return STATUS_SUCCESS;
+    }
+
+    pipewire_capture_padding(stream);
+    if ((packet = stream->locked_ptr))
+    {
+        *params->frames = stream->period_bytes / stream->frame_size;
+        *params->flags = 0;
+        if (packet->discont)
+            *params->flags |= AUDCLNT_BUFFERFLAGS_DATA_DISCONTINUITY;
+        if (params->devpos)
+        {
+            if (packet->discont)
+                *params->devpos = (stream->clock_written + stream->period_bytes) / stream->frame_size;
+            else
+                *params->devpos = stream->clock_written / stream->frame_size;
+        }
+        if (params->qpcpos)
+            *params->qpcpos = packet->qpcpos;
+        *params->data = packet->data;
+    }
+    else
+        *params->frames = 0;
+    stream->locked = *params->frames;
+    pw_thread_loop_unlock(pw_loop_global);
+    params->result = *params->frames ? S_OK : AUDCLNT_S_BUFFER_EMPTY;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_release_capture_buffer(void *args)
+{
+    struct release_capture_buffer_params *params = args;
+    struct pipewire_stream *stream = handle_get_stream(params->stream);
+
+    pw_thread_loop_lock(pw_loop_global);
+    if (!stream->locked && params->done)
+    {
+        pw_thread_loop_unlock(pw_loop_global);
+        params->result = AUDCLNT_E_OUT_OF_ORDER;
+        return STATUS_SUCCESS;
+    }
+    if (params->done && stream->locked != params->done)
+    {
+        pw_thread_loop_unlock(pw_loop_global);
+        params->result = AUDCLNT_E_INVALID_SIZE;
+        return STATUS_SUCCESS;
+    }
+    if (params->done)
+    {
+        ACPacket *packet = stream->locked_ptr;
+        stream->locked_ptr = NULL;
+        stream->held_bytes -= stream->period_bytes;
+        if (packet->discont)
+            stream->clock_written += 2 * stream->period_bytes;
+        else
+            stream->clock_written += stream->period_bytes;
+        list_add_tail(&stream->packet_free_head, &packet->entry);
+    }
+    stream->locked = 0;
+    pw_thread_loop_unlock(pw_loop_global);
+    params->result = S_OK;
+    return STATUS_SUCCESS;
+}
+
+/* ----------------------------------------------------------------------
+ * Clocks / sizes / volumes / events / rate
+ * ---------------------------------------------------------------------- */
+
+static NTSTATUS pipewire_get_current_padding(void *args)
+{
+    struct get_current_padding_params *params = args;
+    struct pipewire_stream *stream = handle_get_stream(params->stream);
+
+    pw_thread_loop_lock(pw_loop_global);
+    if (!stream_valid(stream))
+    {
+        pw_thread_loop_unlock(pw_loop_global);
+        params->result = AUDCLNT_E_DEVICE_INVALIDATED;
+        return STATUS_SUCCESS;
+    }
+
+    if (stream->dataflow == eRender)
+        *params->padding = pipewire_render_padding(stream);
+    else
+        *params->padding = pipewire_capture_padding(stream);
+    pw_thread_loop_unlock(pw_loop_global);
+
+    params->result = S_OK;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_get_buffer_size(void *args)
+{
+    struct get_buffer_size_params *params = args;
+    struct pipewire_stream *stream = handle_get_stream(params->stream);
+
+    params->result = S_OK;
+    pw_thread_loop_lock(pw_loop_global);
+    if (!stream_valid(stream))
+        params->result = AUDCLNT_E_DEVICE_INVALIDATED;
+    else
+        *params->frames = stream->bufsize_frames;
+    pw_thread_loop_unlock(pw_loop_global);
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_get_latency(void *args)
+{
+    struct get_latency_params *params = args;
+    struct pipewire_stream *stream = handle_get_stream(params->stream);
+    REFERENCE_TIME lat;
+
+    pw_thread_loop_lock(pw_loop_global);
+    if (!stream_valid(stream))
+    {
+        pw_thread_loop_unlock(pw_loop_global);
+        params->result = AUDCLNT_E_DEVICE_INVALIDATED;
+        return STATUS_SUCCESS;
+    }
+    lat = stream->period_bytes / stream->frame_size;
+    *params->latency = (lat * 10000000) / stream->info.rate + stream->def_period;
+    pw_thread_loop_unlock(pw_loop_global);
+    params->result = S_OK;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_get_next_packet_size(void *args)
+{
+    struct get_next_packet_size_params *params = args;
+    struct pipewire_stream *stream = handle_get_stream(params->stream);
+
+    pw_thread_loop_lock(pw_loop_global);
+    pipewire_capture_padding(stream);
+    if (stream->locked_ptr)
+        *params->frames = stream->period_bytes / stream->frame_size;
+    else
+        *params->frames = 0;
+    pw_thread_loop_unlock(pw_loop_global);
+    params->result = S_OK;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_get_frequency(void *args)
+{
+    struct get_frequency_params *params = args;
+    struct pipewire_stream *stream = handle_get_stream(params->stream);
+
+    pw_thread_loop_lock(pw_loop_global);
+    if (!stream_valid(stream))
+    {
+        pw_thread_loop_unlock(pw_loop_global);
+        params->result = AUDCLNT_E_DEVICE_INVALIDATED;
+        return STATUS_SUCCESS;
+    }
+
+    *params->freq = stream->info.rate;
+    if (stream->share == AUDCLNT_SHAREMODE_SHARED)
+        *params->freq *= stream->frame_size;
+    pw_thread_loop_unlock(pw_loop_global);
+    params->result = S_OK;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_get_position(void *args)
+{
+    struct get_position_params *params = args;
+    struct pipewire_stream *stream = handle_get_stream(params->stream);
+
+    pw_thread_loop_lock(pw_loop_global);
+    if (!stream_valid(stream))
+    {
+        pw_thread_loop_unlock(pw_loop_global);
+        params->result = AUDCLNT_E_DEVICE_INVALIDATED;
+        return STATUS_SUCCESS;
+    }
+
+    *params->pos = stream->clock_written - stream->held_bytes;
+
+    if (stream->share == AUDCLNT_SHAREMODE_EXCLUSIVE || params->device)
+        *params->pos /= stream->frame_size;
+
+    if (*params->pos < stream->clock_lastpos)
+        *params->pos = stream->clock_lastpos;
+    else
+        stream->clock_lastpos = *params->pos;
+    pw_thread_loop_unlock(pw_loop_global);
+
+    if (params->qpctime)
+    {
+        LARGE_INTEGER stamp, freq;
+        NtQueryPerformanceCounter(&stamp, &freq);
+        *params->qpctime = (stamp.QuadPart * (INT64)10000000) / freq.QuadPart;
+    }
+
+    params->result = S_OK;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_set_volumes(void *args)
+{
+    struct set_volumes_params *params = args;
+    struct pipewire_stream *stream = handle_get_stream(params->stream);
+    unsigned int i;
+
+    for (i = 0; i < stream->info.channels; i++)
+        stream->vol[i] = params->volumes[i] * params->master_volume * params->session_volumes[i];
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_set_event_handle(void *args)
+{
+    struct set_event_handle_params *params = args;
+    struct pipewire_stream *stream = handle_get_stream(params->stream);
+    HRESULT hr = S_OK;
+
+    pw_thread_loop_lock(pw_loop_global);
+    if (!stream_valid(stream))
+        hr = AUDCLNT_E_DEVICE_INVALIDATED;
+    else if (!(stream->flags & AUDCLNT_STREAMFLAGS_EVENTCALLBACK))
+        hr = AUDCLNT_E_EVENTHANDLE_NOT_EXPECTED;
+    else if (stream->event)
+        hr = HRESULT_FROM_WIN32(ERROR_INVALID_NAME);
+    else
+        stream->event = params->event;
+    pw_thread_loop_unlock(pw_loop_global);
+
+    params->result = hr;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_set_sample_rate(void *args)
+{
+    struct set_sample_rate_params *params = args;
+    struct pipewire_stream *stream = handle_get_stream(params->stream);
+    HRESULT hr = S_OK;
+    float ratio;
+
+    pw_thread_loop_lock(pw_loop_global);
+    if (!stream_valid(stream))
+    {
+        hr = AUDCLNT_E_DEVICE_INVALIDATED;
+        goto exit;
+    }
+    if (stream->dataflow != eRender)
+    {
+        hr = E_NOTIMPL;
+        goto exit;
+    }
+
+    ratio = params->rate / (float)stream->info.rate;
+    pw_stream_set_control(stream->pw, SPA_PROP_rate, 1, &ratio, 0);
+
+    pw_stream_flush(stream->pw, false);
+
+    stream->clock_lastpos = stream->clock_written = 0;
+    stream->pa_offs_bytes = stream->lcl_offs_bytes = 0;
+    stream->held_bytes = stream->pa_held_bytes = 0;
+    stream->period_bytes =
+        stream->frame_size * muldiv(stream->mmdev_period_usec, params->rate, 1000000);
+    stream->info.rate = params->rate;
+
+    silence_buffer(stream->info.format, stream->local_buffer, stream->real_bufsize_bytes);
+
+exit:
+    pw_thread_loop_unlock(pw_loop_global);
+    params->result = hr;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_is_started(void *args)
+{
+    struct is_started_params *params = args;
+    struct pipewire_stream *stream = handle_get_stream(params->stream);
+
+    pw_thread_loop_lock(pw_loop_global);
+    params->result = stream_valid(stream) && stream->started ? S_OK : S_FALSE;
+    pw_thread_loop_unlock(pw_loop_global);
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_get_loopback_capture_device(void *args)
+{
+    struct get_loopback_capture_device_params *params = args;
+    const char *device = params->device;
+    const char *sink;
+    UINT32 needed;
+
+    /* Resolve the render device string to a concrete sink node name; an
+     * empty string means the session-manager default sink.  create_stream
+     * then sets PW_KEY_STREAM_CAPTURE_SINK for that name. */
+    if (device && device[0])
+    {
+        if (!device_is_sink(device))
+        {
+            params->result = E_FAIL;
+            return STATUS_SUCCESS;
+        }
+        sink = device;
+    }
+    else
+        sink = g_default_sink;
+
+    needed = strlen(sink) + 1;
+    if (params->ret_device_len < needed || !params->ret_device)
+    {
+        params->ret_device_len = needed;
+        params->result = STATUS_BUFFER_TOO_SMALL;
+        return STATUS_SUCCESS;
+    }
+    memcpy(params->ret_device, sink, needed);
+    params->result = S_OK;
+    return STATUS_SUCCESS;
+}
+
+/* ----------------------------------------------------------------------
+ * MIDI delegation + dispatch tables
+ * ---------------------------------------------------------------------- */
+
+static NTSTATUS pipewire_midi_get_driver(void *args)
+{
+    static const WCHAR driver[] = {'a','l','s','a',0};
+
+    /* Delegate MIDI to winealsa, exactly as winepulse does. */
+    memcpy(args, driver, sizeof(driver));
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pipewire_not_implemented(void *args)
+{
+    return STATUS_SUCCESS;
+}
+
+const unixlib_entry_t __wine_unix_call_funcs[] =
+{
+    pipewire_process_attach,
+    pipewire_process_detach,
+    pipewire_main_loop_start,
+    pipewire_main_loop_stop,
+    pipewire_get_endpoint_ids,
+    pipewire_create_stream,
+    pipewire_release_stream,
+    pipewire_start,
+    pipewire_stop,
+    pipewire_reset,
+    pipewire_get_render_buffer,
+    pipewire_release_render_buffer,
+    pipewire_get_capture_buffer,
+    pipewire_release_capture_buffer,
+    pipewire_is_format_supported,
+    pipewire_get_loopback_capture_device,
+    pipewire_get_mix_format,
+    pipewire_get_device_period,
+    pipewire_get_buffer_size,
+    pipewire_get_latency,
+    pipewire_get_current_padding,
+    pipewire_get_next_packet_size,
+    pipewire_get_frequency,
+    pipewire_get_position,
+    pipewire_set_volumes,
+    pipewire_set_event_handle,
+    pipewire_set_sample_rate,
+    pipewire_test_connect,
+    pipewire_is_started,
+    pipewire_get_prop_value,
+    pipewire_midi_get_driver,
+    pipewire_not_implemented,
+    pipewire_not_implemented,
+    pipewire_not_implemented,
+    pipewire_not_implemented,
+    pipewire_not_implemented,
+    pipewire_not_implemented,
+};
+
+C_ASSERT(ARRAYSIZE(__wine_unix_call_funcs) == funcs_count);
+
+#ifdef _WIN64
+
+/* 32-bit (WoW64) processes are not supported yet.  Returning a failure status
+ * makes mmdevapi's load_driver skip this driver, so those processes fall back
+ * to the next entry in the driver list (e.g. pulse).  load_driver inspects this
+ * status directly via the raw __wine_unix_call, so the asserting wine_unix_call
+ * wrapper is never reached for an unloaded driver. */
+static NTSTATUS pipewire_wow64_not_supported(void *args)
+{
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+const unixlib_entry_t __wine_unix_call_wow64_funcs[] =
+{
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+    pipewire_wow64_not_supported,
+};
+
+C_ASSERT(ARRAYSIZE(__wine_unix_call_wow64_funcs) == funcs_count);
+
+#endif /* _WIN64 */

--- a/dlls/winepipewire.drv/pipewire.c
+++ b/dlls/winepipewire.drv/pipewire.c
@@ -35,6 +35,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <pthread.h>
+#include <time.h>
 
 #include <pipewire/pipewire.h>
 #include <pipewire/extensions/metadata.h>
@@ -1885,10 +1886,31 @@ static void pipewire_period_timer_loop(void *args)
         }
 
         if (period->timer_stream && period->timer_stream->pw &&
-            pw_stream_get_time_n(period->timer_stream->pw, &pwt, sizeof(pwt)) == 0 && pwt.now)
+            pw_stream_get_time_n(period->timer_stream->pw, &pwt, sizeof(pwt)) == 0 &&
+            pwt.now && pwt.rate.denom)
         {
-            now = (UINT64)pwt.now / 1000;
-            have_now = 1;
+            struct timespec ts;
+            UINT64 mono_ns;
+
+            clock_gettime(CLOCK_MONOTONIC, &ts);
+            mono_ns = (UINT64)ts.tv_sec * 1000000000 + ts.tv_nsec;
+
+            /* pwt.now and pwt.ticks only advance once per graph cycle, so
+             * comparing the continuous period grid against them directly
+             * makes the grid chase quantum-sized steps with clamp-sized
+             * corrections every tick (the wakeup cadence smears across
+             * period +/- period/2 whenever the quantum does not divide the
+             * period).  Extrapolate the graph clock to the sampling instant
+             * instead, like winepulse's PA_STREAM_INTERPOLATE_TIMING, and
+             * treat a graph that stopped updating as having no clock so the
+             * grid free-runs at the nominal period and re-acquires on
+             * resume. */
+            if (mono_ns >= (UINT64)pwt.now && mono_ns - pwt.now < 1000000000)
+            {
+                now = pwt.ticks * (UINT64)pwt.rate.num * 1000000 / pwt.rate.denom
+                      + (mono_ns - pwt.now) / 1000;
+                have_now = 1;
+            }
         }
 
         if (!have_now)

--- a/dlls/winepipewire.drv/pipewire.c
+++ b/dlls/winepipewire.drv/pipewire.c
@@ -77,6 +77,7 @@ struct pipewire_stream
     struct spa_hook stream_listener;
     struct spa_audio_info_raw info;
     UINT32 frame_size;
+    UINT32 rate_connected; /* negotiated stream rate; SPA_PROP_rate is absolute vs this */
 
     DWORD flags;
     AUDCLNT_SHAREMODE share;
@@ -1610,6 +1611,8 @@ static NTSTATUS pipewire_create_stream(void *args)
     if (FAILED(hr))
         goto exit;
 
+    stream->rate_connected = stream->info.rate;
+
     if (stream->dataflow == eRender)
     {
         size = stream->real_bufsize_bytes = stream->bufsize_frames * 2 * stream->frame_size;
@@ -2482,8 +2485,13 @@ static NTSTATUS pipewire_set_sample_rate(void *args)
         goto exit;
     }
 
-    ratio = params->rate / (float)stream->info.rate;
-    pw_stream_set_control(stream->pw, SPA_PROP_rate, 1, &ratio, 0);
+    ratio = params->rate / (float)stream->rate_connected;
+    if (pw_stream_set_control(stream->pw, SPA_PROP_rate, 1, &ratio, 0) < 0)
+    {
+        /* needs PipeWire >= 1.2.6 and an active adaptive resampler */
+        hr = E_NOTIMPL;
+        goto exit;
+    }
 
     pw_stream_flush(stream->pw, false);
 

--- a/dlls/winepipewire.drv/pipewire.c
+++ b/dlls/winepipewire.drv/pipewire.c
@@ -392,7 +392,7 @@ static struct pw_phys_device *add_device(struct list *list, const char *pw_name,
     build_format(&dev->fmt, rate, channels, mask);
     dev->channel_mask = dev->fmt.dwChannelMask;
     dev->def_period = 100000;
-    dev->min_period = 50000;
+    dev->min_period = 30000;
     memcpy(dev->pw_name, pw_name, len + 1);
     list_add_tail(list, &dev->entry);
     TRACE("%s (%s) channels=%u mask=%#x\n", debugstr_w(dev->display), pw_name,
@@ -780,7 +780,7 @@ static void build_device_cache(struct probe *p)
         def->display = utf8_to_wstr("PipeWire");
         def->form = Speakers;
         def->def_period = 100000;
-        def->min_period = 50000;
+        def->min_period = 30000;
         if (def_src)
         {
             def->fmt = def_src->fmt;
@@ -806,7 +806,7 @@ static void build_device_cache(struct probe *p)
         def->display = utf8_to_wstr("PipeWire");
         def->form = Microphone;
         def->def_period = 100000;
-        def->min_period = 50000;
+        def->min_period = 30000;
         if (def_src)
         {
             def->fmt = def_src->fmt;
@@ -1464,8 +1464,12 @@ static HRESULT pipewire_stream_connect(struct pipewire_stream *stream, const cha
     if (appname && (app = wstr_to_str(appname)))
     {
         pw_properties_set(props, PW_KEY_APP_NAME, app);
+        pw_properties_set(props, PW_KEY_NODE_NAME, app);
+        pw_properties_set(props, PW_KEY_NODE_DESCRIPTION, app);
         free(app);
     }
+    else
+        pw_properties_set(props, PW_KEY_NODE_NAME, "winepipewire");
     pw_properties_setf(props, PW_KEY_NODE_LATENCY, "%u/%u", period_frames, stream->info.rate);
     if (device && device[0])
     {

--- a/dlls/winepulse.drv/Makefile.in
+++ b/dlls/winepulse.drv/Makefile.in
@@ -1,6 +1,4 @@
-MODULE    = winepulse.drv
 UNIXLIB   = winepulse.so
-IMPORTS   = dxguid uuid winmm user32 advapi32 ole32
 UNIX_LIBS    = $(PULSE_LIBS) $(PTHREAD_LIBS) $(UDEV_LIBS) -lm
 UNIX_CFLAGS  = $(PULSE_CFLAGS) $(UDEV_CFLAGS)
 

--- a/dlls/winepulse.drv/pulse.c
+++ b/dlls/winepulse.drv/pulse.c
@@ -317,19 +317,47 @@ static void pulse_main_loop_thread_cleanup(void *context)
     pulse_broadcast();
 }
 
-static NTSTATUS pulse_main_loop(void *args)
+static void pulse_main_loop(void *args)
 {
-    struct main_loop_params *params = args;
+    HANDLE event = args;
     int ret;
     pulse_lock();
     pulse_ml = pa_mainloop_new();
     pa_mainloop_set_poll_func(pulse_ml, pulse_poll_func, NULL);
-    NtSetEvent(params->event, NULL);
+    NtSetEvent(event, NULL);
     pthread_cleanup_push(pulse_main_loop_thread_cleanup, NULL);
     pa_mainloop_run(pulse_ml, &ret);
     pthread_cleanup_pop(0);
     pa_mainloop_free(pulse_ml);
     pulse_unlock();
+    PsTerminateSystemThread( 0 );
+}
+
+static HANDLE main_loop_thread;
+
+static NTSTATUS pulse_main_loop_start(void *args)
+{
+    static const WCHAR name[] = {'a','u','d','i','o','_','c','l','i','e','n','t','_','m','a','i','n',0};
+    HANDLE event;
+    NTSTATUS status;
+
+    if (main_loop_thread) return STATUS_SUCCESS;
+
+    NtCreateEvent( &event, EVENT_ALL_ACCESS, NULL, NotificationEvent, FALSE );
+    if (!(status = create_unix_thread( &main_loop_thread, name, pulse_main_loop, event )))
+        NtWaitForSingleObject( event, FALSE, NULL );
+    NtClose( event );
+    return status;
+}
+
+static NTSTATUS pulse_main_loop_stop(void *args)
+{
+    if (main_loop_thread)
+    {
+        NtWaitForSingleObject( main_loop_thread, FALSE, NULL );
+        NtClose( main_loop_thread );
+        main_loop_thread = 0;
+    }
     return STATUS_SUCCESS;
 }
 
@@ -2756,7 +2784,8 @@ const unixlib_entry_t __wine_unix_call_funcs[] =
 {
     pulse_process_attach,
     pulse_process_detach,
-    pulse_main_loop,
+    pulse_main_loop_start,
+    pulse_main_loop_stop,
     pulse_get_endpoint_ids,
     pulse_create_stream,
     pulse_release_stream,
@@ -2798,19 +2827,6 @@ C_ASSERT(ARRAYSIZE(__wine_unix_call_funcs) == funcs_count);
 #ifdef _WIN64
 
 typedef UINT PTR32;
-
-static NTSTATUS pulse_wow64_main_loop(void *args)
-{
-    struct
-    {
-        PTR32 event;
-    } *params32 = args;
-    struct main_loop_params params =
-    {
-        .event = ULongToHandle(params32->event)
-    };
-    return pulse_main_loop(&params);
-}
 
 static NTSTATUS pulse_wow64_get_endpoint_ids(void *args)
 {
@@ -3254,7 +3270,8 @@ const unixlib_entry_t __wine_unix_call_wow64_funcs[] =
 {
     pulse_process_attach,
     pulse_process_detach,
-    pulse_wow64_main_loop,
+    pulse_main_loop_start,
+    pulse_main_loop_stop,
     pulse_wow64_get_endpoint_ids,
     pulse_wow64_create_stream,
     pulse_wow64_release_stream,

--- a/dlls/winepulse.drv/pulse.c
+++ b/dlls/winepulse.drv/pulse.c
@@ -1709,12 +1709,6 @@ static void pulse_read(struct pulse_stream *stream)
     }
 }
 
-static NTSTATUS pulse_timer_loop(void *args)
-{
-    /* Stream's data are read and written from the main loop timer callback. */
-    return STATUS_SUCCESS;
-}
-
 static void pa_streams_timer_cb(pa_mainloop_api *api, pa_time_event *e, const struct timeval *tv, void *userdata)
 {
     pa_usec_t now = pa_rtclock_now(), next_timer, stream_time = 0;
@@ -1880,11 +1874,6 @@ static NTSTATUS pulse_release_stream(void *args)
     struct pulse_stream *stream = handle_get_stream(params->stream);
     SIZE_T size;
 
-    if(params->timer_thread) {
-        NtWaitForSingleObject(params->timer_thread, FALSE, NULL);
-        NtClose(params->timer_thread);
-    }
-
     pulse_lock();
     remove_stream_from_period(stream);
     if (PA_STREAM_IS_GOOD(pa_stream_get_state(stream->stream))) {
@@ -1915,6 +1904,7 @@ static NTSTATUS pulse_start(void *args)
 {
     struct start_params *params = args;
     struct pulse_stream *stream = handle_get_stream(params->stream);
+    static const WCHAR name[] = {'a','u','d','i','o','_','c','l','i','e','n','t','_','t','i','m','e','r',0};
     int success;
 
     params->result = S_OK;
@@ -2792,7 +2782,6 @@ const unixlib_entry_t __wine_unix_call_funcs[] =
     pulse_start,
     pulse_stop,
     pulse_reset,
-    pulse_timer_loop,
     pulse_get_render_buffer,
     pulse_release_render_buffer,
     pulse_get_capture_buffer,
@@ -2892,13 +2881,11 @@ static NTSTATUS pulse_wow64_release_stream(void *args)
     struct
     {
         stream_handle stream;
-        PTR32 timer_thread;
         HRESULT result;
     } *params32 = args;
     struct release_stream_params params =
     {
         .stream = params32->stream,
-        .timer_thread = ULongToHandle(params32->timer_thread)
     };
     pulse_release_stream(&params);
     params32->result = params.result;
@@ -3278,7 +3265,6 @@ const unixlib_entry_t __wine_unix_call_wow64_funcs[] =
     pulse_start,
     pulse_stop,
     pulse_reset,
-    pulse_timer_loop,
     pulse_wow64_get_render_buffer,
     pulse_release_render_buffer,
     pulse_wow64_get_capture_buffer,

--- a/dlls/wow64/virtual.c
+++ b/dlls/wow64/virtual.c
@@ -693,11 +693,11 @@ NTSTATUS WINAPI wow64_NtQueryVirtualMemory( UINT *args )
         break;
     }
 
-    case MemoryWineUnixWow64Funcs:
+    case MemoryWineLoadUnixLibWow64:
         return STATUS_INVALID_INFO_CLASS;
 
-    case MemoryWineUnixFuncs:
-        status = NtQueryVirtualMemory( handle, addr, MemoryWineUnixWow64Funcs, ptr, len, &res_len );
+    case MemoryWineLoadUnixLib:
+        status = NtQueryVirtualMemory( handle, addr, MemoryWineLoadUnixLibWow64, ptr, len, &res_len );
         break;
 
     default:

--- a/dlls/wow64/virtual.c
+++ b/dlls/wow64/virtual.c
@@ -694,10 +694,23 @@ NTSTATUS WINAPI wow64_NtQueryVirtualMemory( UINT *args )
     }
 
     case MemoryWineLoadUnixLibWow64:
+    case MemoryWineLoadUnixLibByNameWow64:
         return STATUS_INVALID_INFO_CLASS;
 
     case MemoryWineLoadUnixLib:
         status = NtQueryVirtualMemory( handle, addr, MemoryWineLoadUnixLibWow64, ptr, len, &res_len );
+        break;
+    case MemoryWineLoadUnixLibByName:
+    {
+        UNICODE_STRING32 *str32 = addr;
+        UNICODE_STRING str;
+
+        status = NtQueryVirtualMemory( handle, unicode_str_32to64( &str, str32 ),
+                                       MemoryWineLoadUnixLibByNameWow64, ptr, len, &res_len );
+        break;
+    }
+    case MemoryWineUnloadUnixLib:
+        status = NtQueryVirtualMemory( handle, addr, class, ptr, len, &res_len );
         break;
 
     default:

--- a/include/wine/server_protocol.h
+++ b/include/wine/server_protocol.h
@@ -977,6 +977,12 @@ struct obj_locator
 #define WH_WINEVENT      (WH_MAXHOOK + 1)
 #define NB_HOOKS         (WH_WINEVENT - WH_MINHOOK + 1)
 
+struct directory_file_entry
+{
+    data_size_t name_len;
+
+};
+
 struct shared_cursor
 {
     int                  x;
@@ -1148,6 +1154,13 @@ struct get_startup_info_reply
 };
 
 
+struct cpu_topology_override
+{
+    unsigned int cpu_count;
+    unsigned char host_cpu_id[64];
+};
+
+
 
 struct init_process_done_request
 {
@@ -1155,6 +1168,7 @@ struct init_process_done_request
     char __pad_12[4];
     client_ptr_t teb;
     client_ptr_t peb;
+    client_ptr_t ldt_copy;
 };
 struct init_process_done_reply
 {
@@ -1173,6 +1187,7 @@ struct init_first_thread_request
     int          debug_level;
     int          reply_fd;
     int          wait_fd;
+    /* VARARG(cpu_override,cpu_topology_override); */
 };
 struct init_first_thread_reply
 {
@@ -1417,12 +1432,14 @@ struct suspend_thread_request
 {
     struct request_header __header;
     obj_handle_t handle;
+    obj_handle_t waited_handle;
+    char __pad_20[4];
 };
 struct suspend_thread_reply
 {
     struct reply_header __header;
     int          count;
-    char __pad_12[4];
+    obj_handle_t wait_handle;
 };
 
 
@@ -2607,6 +2624,25 @@ struct flush_key_request
 struct flush_key_reply
 {
     struct reply_header __header;
+    abstime_t   timestamp_counter;
+    data_size_t total;
+    int         branch_count;
+    /* VARARG(data,bytes); */
+};
+
+
+
+struct flush_key_done_request
+{
+    struct request_header __header;
+    char __pad_12[4];
+    abstime_t    timestamp_counter;
+    int          branch;
+    char __pad_28[4];
+};
+struct flush_key_done_reply
+{
+    struct reply_header __header;
 };
 
 
@@ -2733,12 +2769,19 @@ struct save_registry_request
 {
     struct request_header __header;
     obj_handle_t hkey;
-    obj_handle_t file;
-    char __pad_20[4];
 };
 struct save_registry_reply
 {
     struct reply_header __header;
+    data_size_t  total;
+    /* VARARG(data,bytes); */
+    char __pad_12[4];
+};
+enum prefix_type
+{
+    PREFIX_UNKNOWN,
+    PREFIX_32BIT,
+    PREFIX_64BIT,
 };
 
 
@@ -3124,7 +3167,22 @@ struct send_hardware_message_reply
     int             new_y;
     char __pad_28[4];
 };
-#define SEND_HWMSG_INJECTED    0x01
+
+
+
+struct track_mouse_from_pointer_request
+{
+    struct request_header __header;
+    user_handle_t   win;
+    unsigned int    msg;
+    unsigned int    pointer_id;
+};
+struct track_mouse_from_pointer_reply
+{
+    struct reply_header __header;
+    int             cursor_pos_updated;
+    char __pad_12[4];
+};
 
 
 
@@ -4167,6 +4225,7 @@ struct set_user_object_info_request
     obj_handle_t handle;
     unsigned int flags;
     unsigned int obj_flags;
+    timeout_t    close_timeout;
 };
 struct set_user_object_info_reply
 {
@@ -4177,6 +4236,7 @@ struct set_user_object_info_reply
 };
 #define SET_USER_OBJECT_SET_FLAGS       1
 #define SET_USER_OBJECT_GET_FULL_NAME   2
+#define SET_USER_OBJECT_SET_CLOSE_TIMEOUT 4
 
 
 
@@ -4243,12 +4303,12 @@ struct get_thread_input_reply
 
 
 
-struct get_last_input_time_request
+struct set_user_input_time_request
 {
     struct request_header __header;
-    char __pad_12[4];
+    int          set;
 };
-struct get_last_input_time_reply
+struct set_user_input_time_reply
 {
     struct reply_header __header;
     unsigned int time;
@@ -4993,11 +5053,13 @@ struct get_security_object_reply
 
 struct handle_info
 {
+    client_ptr_t object;
     process_id_t owner;
     obj_handle_t handle;
     unsigned int access;
     unsigned int attributes;
     unsigned int type;
+    unsigned int __pad;
 };
 
 
@@ -5132,6 +5194,20 @@ struct get_directory_entries_reply
     /* VARARG(entries,directory_entries); */
 };
 
+struct query_directory_file_request
+{
+    struct request_header __header;
+    obj_handle_t   handle;
+    unsigned int   restart_scan;
+    char __pad_20[4];
+};
+struct query_directory_file_reply
+{
+    struct reply_header __header;
+    data_size_t    total_len;
+    /* VARARG(entries,directory_file_entries); */
+    char __pad_12[4];
+};
 
 
 struct create_symlink_request
@@ -5403,6 +5479,7 @@ struct make_process_system_request
 {
     struct request_header __header;
     obj_handle_t handle;
+    timeout_t    desktop_close_timeout;
 };
 struct make_process_system_reply
 {
@@ -5999,6 +6076,8 @@ struct get_inproc_sync_fd_reply
     struct reply_header __header;
     int           type;
     unsigned int access;
+    unsigned int fsync_shm_idx;
+    char __pad_20[4];
 };
 
 
@@ -6012,7 +6091,7 @@ struct get_inproc_alert_fd_reply
 {
     struct reply_header __header;
     obj_handle_t handle;
-    char __pad_12[4];
+    unsigned int fsync_shm_idx;
 };
 
 
@@ -6159,6 +6238,31 @@ struct d3dkmt_mutex_release_reply
 };
 
 
+#define FSYNC_SHM_PAGE_SIZE 0x10000
+#define FSYNC_USED_BY_SERVER 0x7eadfeef
+
+enum fsync_type
+{
+    FSYNC_SEMAPHORE = 1,
+    FSYNC_AUTO_EVENT,
+    FSYNC_MANUAL_EVENT,
+    FSYNC_MUTEX,
+    FSYNC_AUTO_SERVER,
+    FSYNC_MANUAL_SERVER,
+    FSYNC_QUEUE,
+};
+
+struct fsync_free_shm_idx_request
+{
+    struct request_header __header;
+    unsigned int shm_idx;
+};
+struct fsync_free_shm_idx_reply
+{
+    struct reply_header __header;
+};
+
+
 enum request
 {
     REQ_new_process,
@@ -6251,6 +6355,7 @@ enum request
     REQ_open_key,
     REQ_delete_key,
     REQ_flush_key,
+    REQ_flush_key_done,
     REQ_enum_key,
     REQ_set_key_value,
     REQ_get_key_value,
@@ -6283,6 +6388,7 @@ enum request
     REQ_send_message,
     REQ_post_quit_message,
     REQ_send_hardware_message,
+    REQ_track_mouse_from_pointer,
     REQ_get_message,
     REQ_reply_message,
     REQ_accept_hardware_message,
@@ -6350,7 +6456,7 @@ enum request
     REQ_unregister_hotkey,
     REQ_attach_thread_input,
     REQ_get_thread_input,
-    REQ_get_last_input_time,
+    REQ_set_user_input_time,
     REQ_get_key_state,
     REQ_set_key_state,
     REQ_set_foreground_window,
@@ -6403,6 +6509,7 @@ enum request
     REQ_create_directory,
     REQ_open_directory,
     REQ_get_directory_entries,
+    REQ_query_directory_file,
     REQ_create_symlink,
     REQ_open_symlink,
     REQ_query_symlink,
@@ -6467,6 +6574,7 @@ enum request
     REQ_d3dkmt_object_open_name,
     REQ_d3dkmt_mutex_acquire,
     REQ_d3dkmt_mutex_release,
+    REQ_fsync_free_shm_idx,
     REQ_NB_REQUESTS
 };
 
@@ -6564,6 +6672,7 @@ union generic_request
     struct open_key_request open_key_request;
     struct delete_key_request delete_key_request;
     struct flush_key_request flush_key_request;
+    struct flush_key_done_request flush_key_done_request;
     struct enum_key_request enum_key_request;
     struct set_key_value_request set_key_value_request;
     struct get_key_value_request get_key_value_request;
@@ -6596,6 +6705,7 @@ union generic_request
     struct send_message_request send_message_request;
     struct post_quit_message_request post_quit_message_request;
     struct send_hardware_message_request send_hardware_message_request;
+    struct track_mouse_from_pointer_request track_mouse_from_pointer_request;
     struct get_message_request get_message_request;
     struct reply_message_request reply_message_request;
     struct accept_hardware_message_request accept_hardware_message_request;
@@ -6663,7 +6773,7 @@ union generic_request
     struct unregister_hotkey_request unregister_hotkey_request;
     struct attach_thread_input_request attach_thread_input_request;
     struct get_thread_input_request get_thread_input_request;
-    struct get_last_input_time_request get_last_input_time_request;
+    struct set_user_input_time_request set_user_input_time_request;
     struct get_key_state_request get_key_state_request;
     struct set_key_state_request set_key_state_request;
     struct set_foreground_window_request set_foreground_window_request;
@@ -6716,6 +6826,7 @@ union generic_request
     struct create_directory_request create_directory_request;
     struct open_directory_request open_directory_request;
     struct get_directory_entries_request get_directory_entries_request;
+    struct query_directory_file_request query_directory_file_request;
     struct create_symlink_request create_symlink_request;
     struct open_symlink_request open_symlink_request;
     struct query_symlink_request query_symlink_request;
@@ -6780,6 +6891,7 @@ union generic_request
     struct d3dkmt_object_open_name_request d3dkmt_object_open_name_request;
     struct d3dkmt_mutex_acquire_request d3dkmt_mutex_acquire_request;
     struct d3dkmt_mutex_release_request d3dkmt_mutex_release_request;
+    struct fsync_free_shm_idx_request fsync_free_shm_idx_request;
 };
 union generic_reply
 {
@@ -6875,6 +6987,7 @@ union generic_reply
     struct open_key_reply open_key_reply;
     struct delete_key_reply delete_key_reply;
     struct flush_key_reply flush_key_reply;
+    struct flush_key_done_reply flush_key_done_reply;
     struct enum_key_reply enum_key_reply;
     struct set_key_value_reply set_key_value_reply;
     struct get_key_value_reply get_key_value_reply;
@@ -6907,6 +7020,7 @@ union generic_reply
     struct send_message_reply send_message_reply;
     struct post_quit_message_reply post_quit_message_reply;
     struct send_hardware_message_reply send_hardware_message_reply;
+    struct track_mouse_from_pointer_reply track_mouse_from_pointer_reply;
     struct get_message_reply get_message_reply;
     struct reply_message_reply reply_message_reply;
     struct accept_hardware_message_reply accept_hardware_message_reply;
@@ -6974,7 +7088,7 @@ union generic_reply
     struct unregister_hotkey_reply unregister_hotkey_reply;
     struct attach_thread_input_reply attach_thread_input_reply;
     struct get_thread_input_reply get_thread_input_reply;
-    struct get_last_input_time_reply get_last_input_time_reply;
+    struct set_user_input_time_reply set_user_input_time_reply;
     struct get_key_state_reply get_key_state_reply;
     struct set_key_state_reply set_key_state_reply;
     struct set_foreground_window_reply set_foreground_window_reply;
@@ -7027,6 +7141,7 @@ union generic_reply
     struct create_directory_reply create_directory_reply;
     struct open_directory_reply open_directory_reply;
     struct get_directory_entries_reply get_directory_entries_reply;
+    struct query_directory_file_reply query_directory_file_reply;
     struct create_symlink_reply create_symlink_reply;
     struct open_symlink_reply open_symlink_reply;
     struct query_symlink_reply query_symlink_reply;
@@ -7091,8 +7206,9 @@ union generic_reply
     struct d3dkmt_object_open_name_reply d3dkmt_object_open_name_reply;
     struct d3dkmt_mutex_acquire_reply d3dkmt_mutex_acquire_reply;
     struct d3dkmt_mutex_release_reply d3dkmt_mutex_release_reply;
+    struct fsync_free_shm_idx_reply fsync_free_shm_idx_reply;
 };
 
-#define SERVER_PROTOCOL_VERSION 930
+#define SERVER_PROTOCOL_VERSION 931
 
 #endif /* __WINE_WINE_SERVER_PROTOCOL_H */

--- a/include/wine/unixlib.h
+++ b/include/wine/unixlib.h
@@ -275,6 +275,9 @@ NTSYSAPI int ntdll_wcsnicmp( const WCHAR *str1, const WCHAR *str2, int n );
 extern unixlib_handle_t __wine_unixlib_handle;
 extern NTSTATUS (WINAPI *__wine_unix_call_dispatcher)( unixlib_handle_t, unsigned int, void * );
 extern NTSTATUS WINAPI __wine_init_unix_call(void);
+extern NTSTATUS WINAPI __wine_load_unix_lib( const UNICODE_STRING *name, unixlib_module_t *lib,
+                                             unixlib_handle_t *handle );
+extern NTSTATUS WINAPI __wine_unload_unix_lib( unixlib_module_t lib );
 
 #ifdef __arm64ec__
 NTSTATUS __wine_unix_call_arm64ec( unixlib_handle_t handle, unsigned int code, void *args );

--- a/include/wine/unixlib.h
+++ b/include/wine/unixlib.h
@@ -28,6 +28,7 @@
 #include <winternl.h>
 
 typedef UINT64 unixlib_handle_t;
+typedef UINT64 unixlib_module_t;
 
 #ifdef WINE_UNIX_LIB
 

--- a/include/winternl.h
+++ b/include/winternl.h
@@ -5413,6 +5413,11 @@ NTSYSAPI LONGLONG  WINAPI RtlLargeIntegerSubtract(LONGLONG,LONGLONG);
 NTSYSAPI NTSTATUS  WINAPI RtlLargeIntegerToChar(const ULONGLONG *,ULONG,ULONG,PCHAR);
 #endif
 
+#ifdef WINE_UNIX_LIB
+NTSYSAPI NTSTATUS  WINAPI PsCreateSystemThread(PHANDLE,ULONG,POBJECT_ATTRIBUTES,HANDLE,PCLIENT_ID,PRTL_THREAD_START_ROUTINE,PVOID);
+NTSYSAPI NTSTATUS  WINAPI PsTerminateSystemThread(NTSTATUS);
+#endif
+
 /* Wine internal functions */
 
 NTSYSAPI NTSTATUS WINAPI __wine_get_unix_env( const char *var, char *val, unsigned int buffer_len );

--- a/include/winternl.h
+++ b/include/winternl.h
@@ -2465,6 +2465,9 @@ typedef enum _MEMORY_INFORMATION_CLASS {
 #ifdef __WINESRC__
     MemoryWineLoadUnixLib = 1000,
     MemoryWineLoadUnixLibWow64,
+    MemoryWineLoadUnixLibByName,
+    MemoryWineLoadUnixLibByNameWow64,
+    MemoryWineUnloadUnixLib,
 #endif
     MemoryFexStatsShm = 2000,
 } MEMORY_INFORMATION_CLASS;

--- a/include/winternl.h
+++ b/include/winternl.h
@@ -2463,8 +2463,8 @@ typedef enum _MEMORY_INFORMATION_CLASS {
     MemoryBadInformationAllProcesses = 13,
     MemoryImageExtensionInformation = 14,
 #ifdef __WINESRC__
-    MemoryWineUnixFuncs = 1000,
-    MemoryWineUnixWow64Funcs,
+    MemoryWineLoadUnixLib = 1000,
+    MemoryWineLoadUnixLibWow64,
 #endif
     MemoryFexStatsShm = 2000,
 } MEMORY_INFORMATION_CLASS;

--- a/server/request_handlers.h
+++ b/server/request_handlers.h
@@ -97,6 +97,7 @@ DECL_HANDLER(create_key);
 DECL_HANDLER(open_key);
 DECL_HANDLER(delete_key);
 DECL_HANDLER(flush_key);
+DECL_HANDLER(flush_key_done);
 DECL_HANDLER(enum_key);
 DECL_HANDLER(set_key_value);
 DECL_HANDLER(get_key_value);
@@ -129,6 +130,7 @@ DECL_HANDLER(get_process_idle_event);
 DECL_HANDLER(send_message);
 DECL_HANDLER(post_quit_message);
 DECL_HANDLER(send_hardware_message);
+DECL_HANDLER(track_mouse_from_pointer);
 DECL_HANDLER(get_message);
 DECL_HANDLER(reply_message);
 DECL_HANDLER(accept_hardware_message);
@@ -196,7 +198,7 @@ DECL_HANDLER(register_hotkey);
 DECL_HANDLER(unregister_hotkey);
 DECL_HANDLER(attach_thread_input);
 DECL_HANDLER(get_thread_input);
-DECL_HANDLER(get_last_input_time);
+DECL_HANDLER(set_user_input_time);
 DECL_HANDLER(get_key_state);
 DECL_HANDLER(set_key_state);
 DECL_HANDLER(set_foreground_window);
@@ -249,6 +251,7 @@ DECL_HANDLER(set_mailslot_info);
 DECL_HANDLER(create_directory);
 DECL_HANDLER(open_directory);
 DECL_HANDLER(get_directory_entries);
+DECL_HANDLER(query_directory_file);
 DECL_HANDLER(create_symlink);
 DECL_HANDLER(open_symlink);
 DECL_HANDLER(query_symlink);
@@ -313,6 +316,7 @@ DECL_HANDLER(d3dkmt_share_objects);
 DECL_HANDLER(d3dkmt_object_open_name);
 DECL_HANDLER(d3dkmt_mutex_acquire);
 DECL_HANDLER(d3dkmt_mutex_release);
+DECL_HANDLER(fsync_free_shm_idx);
 
 typedef void (*req_handler)( const void *req, void *reply );
 static const req_handler req_handlers[REQ_NB_REQUESTS] =
@@ -407,6 +411,7 @@ static const req_handler req_handlers[REQ_NB_REQUESTS] =
     (req_handler)req_open_key,
     (req_handler)req_delete_key,
     (req_handler)req_flush_key,
+    (req_handler)req_flush_key_done,
     (req_handler)req_enum_key,
     (req_handler)req_set_key_value,
     (req_handler)req_get_key_value,
@@ -439,6 +444,7 @@ static const req_handler req_handlers[REQ_NB_REQUESTS] =
     (req_handler)req_send_message,
     (req_handler)req_post_quit_message,
     (req_handler)req_send_hardware_message,
+    (req_handler)req_track_mouse_from_pointer,
     (req_handler)req_get_message,
     (req_handler)req_reply_message,
     (req_handler)req_accept_hardware_message,
@@ -506,7 +512,7 @@ static const req_handler req_handlers[REQ_NB_REQUESTS] =
     (req_handler)req_unregister_hotkey,
     (req_handler)req_attach_thread_input,
     (req_handler)req_get_thread_input,
-    (req_handler)req_get_last_input_time,
+    (req_handler)req_set_user_input_time,
     (req_handler)req_get_key_state,
     (req_handler)req_set_key_state,
     (req_handler)req_set_foreground_window,
@@ -559,6 +565,7 @@ static const req_handler req_handlers[REQ_NB_REQUESTS] =
     (req_handler)req_create_directory,
     (req_handler)req_open_directory,
     (req_handler)req_get_directory_entries,
+    (req_handler)req_query_directory_file,
     (req_handler)req_create_symlink,
     (req_handler)req_open_symlink,
     (req_handler)req_query_symlink,
@@ -623,6 +630,7 @@ static const req_handler req_handlers[REQ_NB_REQUESTS] =
     (req_handler)req_d3dkmt_object_open_name,
     (req_handler)req_d3dkmt_mutex_acquire,
     (req_handler)req_d3dkmt_mutex_release,
+    (req_handler)req_fsync_free_shm_idx,
 };
 
 C_ASSERT( sizeof(abstime_t) == 8 );
@@ -648,7 +656,7 @@ C_ASSERT( sizeof(struct context_data) == 1720 );
 C_ASSERT( sizeof(struct cursor_pos) == 24 );
 C_ASSERT( sizeof(struct filesystem_event) == 12 );
 C_ASSERT( sizeof(struct generic_map) == 16 );
-C_ASSERT( sizeof(struct handle_info) == 20 );
+C_ASSERT( sizeof(struct handle_info) == 32 );
 C_ASSERT( sizeof(struct luid) == 8 );
 C_ASSERT( sizeof(struct luid_attr) == 12 );
 C_ASSERT( sizeof(struct obj_locator) == 16 );
@@ -712,7 +720,8 @@ C_ASSERT( offsetof(struct get_startup_info_reply, machine) == 12 );
 C_ASSERT( sizeof(struct get_startup_info_reply) == 16 );
 C_ASSERT( offsetof(struct init_process_done_request, teb) == 16 );
 C_ASSERT( offsetof(struct init_process_done_request, peb) == 24 );
-C_ASSERT( sizeof(struct init_process_done_request) == 32 );
+C_ASSERT( offsetof(struct init_process_done_request, ldt_copy) == 32 );
+C_ASSERT( sizeof(struct init_process_done_request) == 40 );
 C_ASSERT( offsetof(struct init_process_done_reply, suspend) == 8 );
 C_ASSERT( sizeof(struct init_process_done_reply) == 16 );
 C_ASSERT( offsetof(struct init_first_thread_request, unix_pid) == 12 );
@@ -821,8 +830,10 @@ C_ASSERT( offsetof(struct set_thread_info_request, disable_boost) == 44 );
 C_ASSERT( offsetof(struct set_thread_info_request, mask) == 48 );
 C_ASSERT( sizeof(struct set_thread_info_request) == 56 );
 C_ASSERT( offsetof(struct suspend_thread_request, handle) == 12 );
-C_ASSERT( sizeof(struct suspend_thread_request) == 16 );
+C_ASSERT( offsetof(struct suspend_thread_request, waited_handle) == 16 );
+C_ASSERT( sizeof(struct suspend_thread_request) == 24 );
 C_ASSERT( offsetof(struct suspend_thread_reply, count) == 8 );
+C_ASSERT( offsetof(struct suspend_thread_reply, wait_handle) == 12 );
 C_ASSERT( sizeof(struct suspend_thread_reply) == 16 );
 C_ASSERT( offsetof(struct resume_thread_request, handle) == 12 );
 C_ASSERT( sizeof(struct resume_thread_request) == 16 );
@@ -1202,6 +1213,13 @@ C_ASSERT( offsetof(struct delete_key_request, hkey) == 12 );
 C_ASSERT( sizeof(struct delete_key_request) == 16 );
 C_ASSERT( offsetof(struct flush_key_request, hkey) == 12 );
 C_ASSERT( sizeof(struct flush_key_request) == 16 );
+C_ASSERT( offsetof(struct flush_key_reply, timestamp_counter) == 8 );
+C_ASSERT( offsetof(struct flush_key_reply, total) == 16 );
+C_ASSERT( offsetof(struct flush_key_reply, branch_count) == 20 );
+C_ASSERT( sizeof(struct flush_key_reply) == 24 );
+C_ASSERT( offsetof(struct flush_key_done_request, timestamp_counter) == 16 );
+C_ASSERT( offsetof(struct flush_key_done_request, branch) == 24 );
+C_ASSERT( sizeof(struct flush_key_done_request) == 32 );
 C_ASSERT( offsetof(struct enum_key_request, hkey) == 12 );
 C_ASSERT( offsetof(struct enum_key_request, index) == 16 );
 C_ASSERT( offsetof(struct enum_key_request, info_class) == 20 );
@@ -1241,8 +1259,9 @@ C_ASSERT( offsetof(struct unload_registry_request, parent) == 12 );
 C_ASSERT( offsetof(struct unload_registry_request, attributes) == 16 );
 C_ASSERT( sizeof(struct unload_registry_request) == 24 );
 C_ASSERT( offsetof(struct save_registry_request, hkey) == 12 );
-C_ASSERT( offsetof(struct save_registry_request, file) == 16 );
-C_ASSERT( sizeof(struct save_registry_request) == 24 );
+C_ASSERT( sizeof(struct save_registry_request) == 16 );
+C_ASSERT( offsetof(struct save_registry_reply, total) == 8 );
+C_ASSERT( sizeof(struct save_registry_reply) == 16 );
 C_ASSERT( offsetof(struct set_registry_notification_request, hkey) == 12 );
 C_ASSERT( offsetof(struct set_registry_notification_request, event) == 16 );
 C_ASSERT( offsetof(struct set_registry_notification_request, subtree) == 20 );
@@ -1359,6 +1378,12 @@ C_ASSERT( offsetof(struct send_hardware_message_reply, prev_y) == 16 );
 C_ASSERT( offsetof(struct send_hardware_message_reply, new_x) == 20 );
 C_ASSERT( offsetof(struct send_hardware_message_reply, new_y) == 24 );
 C_ASSERT( sizeof(struct send_hardware_message_reply) == 32 );
+C_ASSERT( offsetof(struct track_mouse_from_pointer_request, win) == 12 );
+C_ASSERT( offsetof(struct track_mouse_from_pointer_request, msg) == 16 );
+C_ASSERT( offsetof(struct track_mouse_from_pointer_request, pointer_id) == 20 );
+C_ASSERT( sizeof(struct track_mouse_from_pointer_request) == 24 );
+C_ASSERT( offsetof(struct track_mouse_from_pointer_reply, cursor_pos_updated) == 8 );
+C_ASSERT( sizeof(struct track_mouse_from_pointer_reply) == 16 );
 C_ASSERT( offsetof(struct get_message_request, flags) == 12 );
 C_ASSERT( offsetof(struct get_message_request, get_win) == 16 );
 C_ASSERT( offsetof(struct get_message_request, get_first) == 20 );
@@ -1711,7 +1736,8 @@ C_ASSERT( sizeof(struct set_thread_desktop_reply) == 24 );
 C_ASSERT( offsetof(struct set_user_object_info_request, handle) == 12 );
 C_ASSERT( offsetof(struct set_user_object_info_request, flags) == 16 );
 C_ASSERT( offsetof(struct set_user_object_info_request, obj_flags) == 20 );
-C_ASSERT( sizeof(struct set_user_object_info_request) == 24 );
+C_ASSERT( offsetof(struct set_user_object_info_request, close_timeout) == 24 );
+C_ASSERT( sizeof(struct set_user_object_info_request) == 32 );
 C_ASSERT( offsetof(struct set_user_object_info_reply, is_desktop) == 8 );
 C_ASSERT( offsetof(struct set_user_object_info_reply, old_obj_flags) == 12 );
 C_ASSERT( sizeof(struct set_user_object_info_reply) == 16 );
@@ -1738,9 +1764,10 @@ C_ASSERT( offsetof(struct get_thread_input_request, tid) == 12 );
 C_ASSERT( sizeof(struct get_thread_input_request) == 16 );
 C_ASSERT( offsetof(struct get_thread_input_reply, locator) == 8 );
 C_ASSERT( sizeof(struct get_thread_input_reply) == 24 );
-C_ASSERT( sizeof(struct get_last_input_time_request) == 16 );
-C_ASSERT( offsetof(struct get_last_input_time_reply, time) == 8 );
-C_ASSERT( sizeof(struct get_last_input_time_reply) == 16 );
+C_ASSERT( offsetof(struct set_user_input_time_request, set) == 12 );
+C_ASSERT( sizeof(struct set_user_input_time_request) == 16 );
+C_ASSERT( offsetof(struct set_user_input_time_reply, time) == 8 );
+C_ASSERT( sizeof(struct set_user_input_time_reply) == 16 );
 C_ASSERT( offsetof(struct get_key_state_request, async) == 12 );
 C_ASSERT( offsetof(struct get_key_state_request, key) == 16 );
 C_ASSERT( sizeof(struct get_key_state_request) == 24 );
@@ -2048,6 +2075,11 @@ C_ASSERT( sizeof(struct get_directory_entries_request) == 24 );
 C_ASSERT( offsetof(struct get_directory_entries_reply, total_len) == 8 );
 C_ASSERT( offsetof(struct get_directory_entries_reply, count) == 12 );
 C_ASSERT( sizeof(struct get_directory_entries_reply) == 16 );
+C_ASSERT( offsetof(struct query_directory_file_request, handle) == 12 );
+C_ASSERT( offsetof(struct query_directory_file_request, restart_scan) == 16 );
+C_ASSERT( sizeof(struct query_directory_file_request) == 24 );
+C_ASSERT( offsetof(struct query_directory_file_reply, total_len) == 8 );
+C_ASSERT( sizeof(struct query_directory_file_reply) == 16 );
 C_ASSERT( offsetof(struct create_symlink_request, access) == 12 );
 C_ASSERT( sizeof(struct create_symlink_request) == 16 );
 C_ASSERT( offsetof(struct create_symlink_reply, handle) == 8 );
@@ -2129,7 +2161,8 @@ C_ASSERT( sizeof(struct get_kernel_object_handle_request) == 32 );
 C_ASSERT( offsetof(struct get_kernel_object_handle_reply, handle) == 8 );
 C_ASSERT( sizeof(struct get_kernel_object_handle_reply) == 16 );
 C_ASSERT( offsetof(struct make_process_system_request, handle) == 12 );
-C_ASSERT( sizeof(struct make_process_system_request) == 16 );
+C_ASSERT( offsetof(struct make_process_system_request, desktop_close_timeout) == 16 );
+C_ASSERT( sizeof(struct make_process_system_request) == 24 );
 C_ASSERT( offsetof(struct make_process_system_reply, event) == 8 );
 C_ASSERT( sizeof(struct make_process_system_reply) == 16 );
 C_ASSERT( offsetof(struct grant_process_admin_token_request, handle) == 12 );
@@ -2316,9 +2349,11 @@ C_ASSERT( offsetof(struct get_inproc_sync_fd_request, handle) == 12 );
 C_ASSERT( sizeof(struct get_inproc_sync_fd_request) == 16 );
 C_ASSERT( offsetof(struct get_inproc_sync_fd_reply, type) == 8 );
 C_ASSERT( offsetof(struct get_inproc_sync_fd_reply, access) == 12 );
-C_ASSERT( sizeof(struct get_inproc_sync_fd_reply) == 16 );
+C_ASSERT( offsetof(struct get_inproc_sync_fd_reply, fsync_shm_idx) == 16 );
+C_ASSERT( sizeof(struct get_inproc_sync_fd_reply) == 24 );
 C_ASSERT( sizeof(struct get_inproc_alert_fd_request) == 16 );
 C_ASSERT( offsetof(struct get_inproc_alert_fd_reply, handle) == 8 );
+C_ASSERT( offsetof(struct get_inproc_alert_fd_reply, fsync_shm_idx) == 12 );
 C_ASSERT( sizeof(struct get_inproc_alert_fd_reply) == 16 );
 C_ASSERT( offsetof(struct d3dkmt_object_create_request, type) == 12 );
 C_ASSERT( offsetof(struct d3dkmt_object_create_request, fd) == 16 );
@@ -2373,3 +2408,6 @@ C_ASSERT( offsetof(struct d3dkmt_mutex_release_request, key_value) == 20 );
 C_ASSERT( offsetof(struct d3dkmt_mutex_release_request, fence_value) == 24 );
 C_ASSERT( offsetof(struct d3dkmt_mutex_release_request, runtime_size) == 32 );
 C_ASSERT( sizeof(struct d3dkmt_mutex_release_request) == 40 );
+C_ASSERT( offsetof(struct fsync_free_shm_idx_request, shm_idx) == 12 );
+C_ASSERT( sizeof(struct fsync_free_shm_idx_request) == 16 );
+C_ASSERT( sizeof(struct fsync_free_shm_idx_reply) == 8 );

--- a/server/request_trace.h
+++ b/server/request_trace.h
@@ -22,9 +22,11 @@ static void dump_varargs_apc_call( const char *prefix, data_size_t size );
 static void dump_varargs_apc_result( const char *prefix, data_size_t size );
 static void dump_varargs_bytes( const char *prefix, data_size_t size );
 static void dump_varargs_contexts( const char *prefix, data_size_t size );
+static void dump_varargs_cpu_topology_override( const char *prefix, data_size_t size );
 static void dump_varargs_cursor_positions( const char *prefix, data_size_t size );
 static void dump_varargs_debug_event( const char *prefix, data_size_t size );
 static void dump_varargs_directory_entries( const char *prefix, data_size_t size );
+static void dump_varargs_directory_file_entries( const char *prefix, data_size_t size );
 static void dump_varargs_filesystem_event( const char *prefix, data_size_t size );
 static void dump_varargs_handle_infos( const char *prefix, data_size_t size );
 static void dump_varargs_ints( const char *prefix, data_size_t size );
@@ -125,6 +127,7 @@ static void dump_init_process_done_request( const struct init_process_done_reque
 {
     dump_uint64( " teb=", &req->teb );
     dump_uint64( ", peb=", &req->peb );
+    dump_uint64( ", ldt_copy=", &req->ldt_copy );
 }
 
 static void dump_init_process_done_reply( const struct init_process_done_reply *req )
@@ -139,6 +142,7 @@ static void dump_init_first_thread_request( const struct init_first_thread_reque
     fprintf( stderr, ", debug_level=%d", req->debug_level );
     fprintf( stderr, ", reply_fd=%d", req->reply_fd );
     fprintf( stderr, ", wait_fd=%d", req->wait_fd );
+    dump_varargs_cpu_topology_override( ", cpu_override=", cur_size );
 }
 
 static void dump_init_first_thread_reply( const struct init_first_thread_reply *req )
@@ -312,11 +316,13 @@ static void dump_set_thread_info_request( const struct set_thread_info_request *
 static void dump_suspend_thread_request( const struct suspend_thread_request *req )
 {
     fprintf( stderr, " handle=%04x", req->handle );
+    fprintf( stderr, ", waited_handle=%04x", req->waited_handle );
 }
 
 static void dump_suspend_thread_reply( const struct suspend_thread_reply *req )
 {
     fprintf( stderr, " count=%d", req->count );
+    fprintf( stderr, ", wait_handle=%04x", req->wait_handle );
 }
 
 static void dump_resume_thread_request( const struct resume_thread_request *req )
@@ -1117,6 +1123,20 @@ static void dump_flush_key_request( const struct flush_key_request *req )
     fprintf( stderr, " hkey=%04x", req->hkey );
 }
 
+static void dump_flush_key_reply( const struct flush_key_reply *req )
+{
+    dump_abstime( " timestamp_counter=", &req->timestamp_counter );
+    fprintf( stderr, ", total=%u", req->total );
+    fprintf( stderr, ", branch_count=%d", req->branch_count );
+    dump_varargs_bytes( ", data=", cur_size );
+}
+
+static void dump_flush_key_done_request( const struct flush_key_done_request *req )
+{
+    dump_abstime( " timestamp_counter=", &req->timestamp_counter );
+    fprintf( stderr, ", branch=%d", req->branch );
+}
+
 static void dump_enum_key_request( const struct enum_key_request *req )
 {
     fprintf( stderr, " hkey=%04x", req->hkey );
@@ -1199,7 +1219,12 @@ static void dump_unload_registry_request( const struct unload_registry_request *
 static void dump_save_registry_request( const struct save_registry_request *req )
 {
     fprintf( stderr, " hkey=%04x", req->hkey );
-    fprintf( stderr, ", file=%04x", req->file );
+}
+
+static void dump_save_registry_reply( const struct save_registry_reply *req )
+{
+    fprintf( stderr, " total=%u", req->total );
+    dump_varargs_bytes( ", data=", cur_size );
 }
 
 static void dump_set_registry_notification_request( const struct set_registry_notification_request *req )
@@ -1454,6 +1479,18 @@ static void dump_send_hardware_message_reply( const struct send_hardware_message
     fprintf( stderr, ", prev_y=%d", req->prev_y );
     fprintf( stderr, ", new_x=%d", req->new_x );
     fprintf( stderr, ", new_y=%d", req->new_y );
+}
+
+static void dump_track_mouse_from_pointer_request( const struct track_mouse_from_pointer_request *req )
+{
+    fprintf( stderr, " win=%08x", req->win );
+    fprintf( stderr, ", msg=%08x", req->msg );
+    fprintf( stderr, ", pointer_id=%08x", req->pointer_id );
+}
+
+static void dump_track_mouse_from_pointer_reply( const struct track_mouse_from_pointer_reply *req )
+{
+    fprintf( stderr, " cursor_pos_updated=%d", req->cursor_pos_updated );
 }
 
 static void dump_get_message_request( const struct get_message_request *req )
@@ -2158,6 +2195,7 @@ static void dump_set_user_object_info_request( const struct set_user_object_info
     fprintf( stderr, " handle=%04x", req->handle );
     fprintf( stderr, ", flags=%08x", req->flags );
     fprintf( stderr, ", obj_flags=%08x", req->obj_flags );
+    dump_timeout( ", close_timeout=", &req->close_timeout );
 }
 
 static void dump_set_user_object_info_reply( const struct set_user_object_info_reply *req )
@@ -2211,11 +2249,12 @@ static void dump_get_thread_input_reply( const struct get_thread_input_reply *re
     dump_obj_locator( " locator=", &req->locator );
 }
 
-static void dump_get_last_input_time_request( const struct get_last_input_time_request *req )
+static void dump_set_user_input_time_request( const struct set_user_input_time_request *req )
 {
+    fprintf( stderr, " set=%d", req->set );
 }
 
-static void dump_get_last_input_time_reply( const struct get_last_input_time_reply *req )
+static void dump_set_user_input_time_reply( const struct set_user_input_time_reply *req )
 {
     fprintf( stderr, " time=%08x", req->time );
 }
@@ -2847,6 +2886,18 @@ static void dump_get_directory_entries_reply( const struct get_directory_entries
     dump_varargs_directory_entries( ", entries=", cur_size );
 }
 
+static void dump_query_directory_file_request( const struct query_directory_file_request *req )
+{
+    fprintf( stderr, " handle=%04x", req->handle );
+    fprintf( stderr, ", restart_scan=%08x", req->restart_scan );
+}
+
+static void dump_query_directory_file_reply( const struct query_directory_file_reply *req )
+{
+    fprintf( stderr, " total_len=%u", req->total_len );
+    dump_varargs_directory_file_entries( ", entries=", cur_size );
+}
+
 static void dump_create_symlink_request( const struct create_symlink_request *req )
 {
     fprintf( stderr, " access=%08x", req->access );
@@ -3027,6 +3078,7 @@ static void dump_get_kernel_object_handle_reply( const struct get_kernel_object_
 static void dump_make_process_system_request( const struct make_process_system_request *req )
 {
     fprintf( stderr, " handle=%04x", req->handle );
+    dump_timeout( ", desktop_close_timeout=", &req->desktop_close_timeout );
 }
 
 static void dump_make_process_system_reply( const struct make_process_system_reply *req )
@@ -3395,6 +3447,7 @@ static void dump_get_inproc_sync_fd_reply( const struct get_inproc_sync_fd_reply
 {
     fprintf( stderr, " type=%d", req->type );
     fprintf( stderr, ", access=%08x", req->access );
+    fprintf( stderr, ", fsync_shm_idx=%08x", req->fsync_shm_idx );
 }
 
 static void dump_get_inproc_alert_fd_request( const struct get_inproc_alert_fd_request *req )
@@ -3404,6 +3457,7 @@ static void dump_get_inproc_alert_fd_request( const struct get_inproc_alert_fd_r
 static void dump_get_inproc_alert_fd_reply( const struct get_inproc_alert_fd_reply *req )
 {
     fprintf( stderr, " handle=%04x", req->handle );
+    fprintf( stderr, ", fsync_shm_idx=%08x", req->fsync_shm_idx );
 }
 
 static void dump_d3dkmt_object_create_request( const struct d3dkmt_object_create_request *req )
@@ -3508,6 +3562,11 @@ static void dump_d3dkmt_mutex_release_request( const struct d3dkmt_mutex_release
     dump_varargs_bytes( ", runtime=", cur_size );
 }
 
+static void dump_fsync_free_shm_idx_request( const struct fsync_free_shm_idx_request *req )
+{
+    fprintf( stderr, " shm_idx=%08x", req->shm_idx );
+}
+
 typedef void (*dump_func)( const void *req );
 
 static const dump_func req_dumpers[REQ_NB_REQUESTS] =
@@ -3602,6 +3661,7 @@ static const dump_func req_dumpers[REQ_NB_REQUESTS] =
     (dump_func)dump_open_key_request,
     (dump_func)dump_delete_key_request,
     (dump_func)dump_flush_key_request,
+    (dump_func)dump_flush_key_done_request,
     (dump_func)dump_enum_key_request,
     (dump_func)dump_set_key_value_request,
     (dump_func)dump_get_key_value_request,
@@ -3634,6 +3694,7 @@ static const dump_func req_dumpers[REQ_NB_REQUESTS] =
     (dump_func)dump_send_message_request,
     (dump_func)dump_post_quit_message_request,
     (dump_func)dump_send_hardware_message_request,
+    (dump_func)dump_track_mouse_from_pointer_request,
     (dump_func)dump_get_message_request,
     (dump_func)dump_reply_message_request,
     (dump_func)dump_accept_hardware_message_request,
@@ -3701,7 +3762,7 @@ static const dump_func req_dumpers[REQ_NB_REQUESTS] =
     (dump_func)dump_unregister_hotkey_request,
     (dump_func)dump_attach_thread_input_request,
     (dump_func)dump_get_thread_input_request,
-    (dump_func)dump_get_last_input_time_request,
+    (dump_func)dump_set_user_input_time_request,
     (dump_func)dump_get_key_state_request,
     (dump_func)dump_set_key_state_request,
     (dump_func)dump_set_foreground_window_request,
@@ -3754,6 +3815,7 @@ static const dump_func req_dumpers[REQ_NB_REQUESTS] =
     (dump_func)dump_create_directory_request,
     (dump_func)dump_open_directory_request,
     (dump_func)dump_get_directory_entries_request,
+    (dump_func)dump_query_directory_file_request,
     (dump_func)dump_create_symlink_request,
     (dump_func)dump_open_symlink_request,
     (dump_func)dump_query_symlink_request,
@@ -3818,6 +3880,7 @@ static const dump_func req_dumpers[REQ_NB_REQUESTS] =
     (dump_func)dump_d3dkmt_object_open_name_request,
     (dump_func)dump_d3dkmt_mutex_acquire_request,
     (dump_func)dump_d3dkmt_mutex_release_request,
+    (dump_func)dump_fsync_free_shm_idx_request,
 };
 
 static const dump_func reply_dumpers[REQ_NB_REQUESTS] =
@@ -3911,6 +3974,7 @@ static const dump_func reply_dumpers[REQ_NB_REQUESTS] =
     (dump_func)dump_create_key_reply,
     (dump_func)dump_open_key_reply,
     NULL,
+    (dump_func)dump_flush_key_reply,
     NULL,
     (dump_func)dump_enum_key_reply,
     NULL,
@@ -3919,7 +3983,7 @@ static const dump_func reply_dumpers[REQ_NB_REQUESTS] =
     NULL,
     NULL,
     NULL,
-    NULL,
+    (dump_func)dump_save_registry_reply,
     NULL,
     NULL,
     (dump_func)dump_create_timer_reply,
@@ -3944,6 +4008,7 @@ static const dump_func reply_dumpers[REQ_NB_REQUESTS] =
     NULL,
     NULL,
     (dump_func)dump_send_hardware_message_reply,
+    (dump_func)dump_track_mouse_from_pointer_reply,
     (dump_func)dump_get_message_reply,
     NULL,
     NULL,
@@ -4011,7 +4076,7 @@ static const dump_func reply_dumpers[REQ_NB_REQUESTS] =
     (dump_func)dump_unregister_hotkey_reply,
     NULL,
     (dump_func)dump_get_thread_input_reply,
-    (dump_func)dump_get_last_input_time_reply,
+    (dump_func)dump_set_user_input_time_reply,
     (dump_func)dump_get_key_state_reply,
     NULL,
     (dump_func)dump_set_foreground_window_reply,
@@ -4064,6 +4129,7 @@ static const dump_func reply_dumpers[REQ_NB_REQUESTS] =
     (dump_func)dump_create_directory_reply,
     (dump_func)dump_open_directory_reply,
     (dump_func)dump_get_directory_entries_reply,
+    (dump_func)dump_query_directory_file_reply,
     (dump_func)dump_create_symlink_reply,
     (dump_func)dump_open_symlink_reply,
     (dump_func)dump_query_symlink_reply,
@@ -4127,6 +4193,7 @@ static const dump_func reply_dumpers[REQ_NB_REQUESTS] =
     (dump_func)dump_d3dkmt_share_objects_reply,
     (dump_func)dump_d3dkmt_object_open_name_reply,
     (dump_func)dump_d3dkmt_mutex_acquire_reply,
+    NULL,
     NULL,
 };
 
@@ -4222,6 +4289,7 @@ static const char * const req_names[REQ_NB_REQUESTS] =
     "open_key",
     "delete_key",
     "flush_key",
+    "flush_key_done",
     "enum_key",
     "set_key_value",
     "get_key_value",
@@ -4254,6 +4322,7 @@ static const char * const req_names[REQ_NB_REQUESTS] =
     "send_message",
     "post_quit_message",
     "send_hardware_message",
+    "track_mouse_from_pointer",
     "get_message",
     "reply_message",
     "accept_hardware_message",
@@ -4321,7 +4390,7 @@ static const char * const req_names[REQ_NB_REQUESTS] =
     "unregister_hotkey",
     "attach_thread_input",
     "get_thread_input",
-    "get_last_input_time",
+    "set_user_input_time",
     "get_key_state",
     "set_key_state",
     "set_foreground_window",
@@ -4374,6 +4443,7 @@ static const char * const req_names[REQ_NB_REQUESTS] =
     "create_directory",
     "open_directory",
     "get_directory_entries",
+    "query_directory_file",
     "create_symlink",
     "open_symlink",
     "query_symlink",
@@ -4438,6 +4508,7 @@ static const char * const req_names[REQ_NB_REQUESTS] =
     "d3dkmt_object_open_name",
     "d3dkmt_mutex_acquire",
     "d3dkmt_mutex_release",
+    "fsync_free_shm_idx",
 };
 
 static const struct
@@ -4543,6 +4614,7 @@ static const struct
     { "NO_IMPERSONATION_TOKEN",      STATUS_NO_IMPERSONATION_TOKEN },
     { "NO_MEMORY",                   STATUS_NO_MEMORY },
     { "NO_MORE_ENTRIES",             STATUS_NO_MORE_ENTRIES },
+    { "NO_MORE_FILES",               STATUS_NO_MORE_FILES },
     { "NO_SUCH_DEVICE",              STATUS_NO_SUCH_DEVICE },
     { "NO_SUCH_FILE",                STATUS_NO_SUCH_FILE },
     { "NO_TOKEN",                    STATUS_NO_TOKEN },

--- a/tools/make_makefiles
+++ b/tools/make_makefiles
@@ -140,7 +140,7 @@ sub parse_makefile($)
         while (/\\$/) { chop; $_ .= <MAKE>; chomp; }  # merge continued lines
         next if (/^\s*$/);
 
-        if (/^\s*(MODULE|IMPORTLIB|TESTDLL|STATICLIB|PARENTSRC|EXTRADLLFLAGS)\s*=\s*(.*)/)
+        if (/^\s*(MODULE|IMPORTLIB|TESTDLL|STATICLIB|EXTLIB|UNIXLIB|PARENTSRC|EXTRADLLFLAGS)\s*=\s*(.*)/)
         {
             my $var = $1;
             $make{$var} = $2;
@@ -154,6 +154,7 @@ sub parse_makefile($)
             next;
         }
     }
+    close MAKE;
 
     return %make;
 }
@@ -318,16 +319,22 @@ sub update_makefiles(@)
         next if $file eq "Makefile.in";
         my %make = %{$makefiles{$file}};
         (my $dir = $file) =~ s/^(.*)\/Makefile\.in/$1/;
+
+        die "Only one of MODULE, STATICLIB, EXTLIB, or TESTDLL must be specified in $file"
+            if defined($make{TESTDLL}) + defined($make{STATICLIB}) + defined($make{EXTLIB}) + defined($make{MODULE}) > 1;
+
         if (defined($make{"TESTDLL"}))  # test
         {
             die "TESTDLL should not be defined in $file" unless $file =~ /\/tests\/Makefile\.in$/;
-            die "MODULE should not be defined in $file" if defined $make{"MODULE"};
-            die "STATICLIB should not be defined in $file" if defined $make{"STATICLIB"};
         }
         elsif (defined($make{"STATICLIB"}))
         {
-            die "MODULE should not be defined in $file" if defined $make{"MODULE"};
             die "invalid STATICLIB name" unless $make{"STATICLIB"} =~ /\.a$/;
+        }
+        elsif (defined($make{"EXTLIB"}))
+        {
+            die "EXTLIB should not be defined in $file" unless $file =~ /^libs\//;
+            die "invalid EXTLIB name" unless $make{"EXTLIB"} =~ /\.a$/;
         }
         elsif (defined($make{"MODULE"}))  # dll or program
         {
@@ -335,7 +342,6 @@ sub update_makefiles(@)
             my $dllflags = $make{"EXTRADLLFLAGS"} || "";
             die "invalid MODULE name" if $make{"MODULE"} =~ /\.a$/;
             die "MODULE should not be defined in $file" unless $file =~ /^(dlls|programs)\//;
-            die "STATICLIB should not be defined in $file" if defined $make{"STATICLIB"};
             if ($file =~ /^programs\//)
             {
                 die "EXTRADLLFLAGS should be defined in $file" unless $dllflags;
@@ -357,11 +363,9 @@ sub update_makefiles(@)
                 die "Subsystem should be set to native in $file" unless $dllflags =~ /-Wl,--subsystem,native/;
             }
         }
-        elsif ($file =~ /^tools.*\/Makefile\.in$/)
+        elsif (defined($make{"UNIXLIB"}))
         {
-            die "MODULE should not be defined in $file" if defined $make{"MODULE"};
-            die "STATICLIB should not be defined in $file" if defined $make{"STATICLIB"};
-            die "EXTRADLLFLAGS should not be defined in $file" if defined $make{"EXTRADLLFLAGS"};
+            die "UNIXLIB should not be defined in $file" unless $file =~ /^dlls\/.*\.drv\/Makefile.kin$/;
         }
         push @lines, "WINE_CONFIG_MAKEFILE($dir)\n";
     }

--- a/tools/makedep.c
+++ b/tools/makedep.c
@@ -4120,7 +4120,6 @@ static void output_sources( struct makefile *make )
             if (make->importlib && (is_multiarch( arch ) || (!arch && !is_native_arch_disabled( make ))))
                 output_import_lib( make, arch );
         }
-        if (make->unixlib) output_unix_lib( make );
         if (make->is_exe && !make->is_win16 && unix_lib_supported && strendswith( make->module, ".exe" ))
         {
             char *binary = replace_extension( make->module, ".exe", "" );
@@ -4133,6 +4132,8 @@ static void output_sources( struct makefile *make )
             if (is_multiarch( arch )) output_test_module( make, arch );
     }
     else if (make->programs.count) output_programs( make );
+
+    if (make->unixlib) output_unix_lib( make );
 
     STRARRAY_FOR_EACH( script, &make->scripts ) install_script( make, script );
 
@@ -4608,22 +4609,19 @@ static void load_sources( struct makefile *make )
     make->is_exe     = strarray_exists( make->extradllflags, "-mconsole" ) ||
                        strarray_exists( make->extradllflags, "-mwindows" );
 
-    if (make->module)
+    /* add default install rules if nothing was specified */
+    for (i = 0; i < NB_INSTALL_RULES; i++) if (make->install[i].count) break;
+    if (i == NB_INSTALL_RULES && !make->extlib)
     {
-        /* add default install rules if nothing was specified */
-        for (i = 0; i < NB_INSTALL_RULES; i++) if (make->install[i].count) break;
-        if (i == NB_INSTALL_RULES && !make->extlib)
+        if (make->unixlib) strarray_add( &make->install[INSTALL_UNIXLIB], make->unixlib );
+        if (make->importlib) strarray_add( &make->install[INSTALL_DEV], make->importlib );
+        if (make->staticlib) strarray_add( &make->install[INSTALL_DEV], make->staticlib );
+        else if (make->module) strarray_add( &make->install[INSTALL_LIB], make->module );
+        for (arch = 1; arch < archs.count; arch++)
         {
-            if (make->unixlib) strarray_add( &make->install[INSTALL_UNIXLIB], make->unixlib );
-            if (make->importlib) strarray_add( &make->install[INSTALL_DEV], make->importlib );
-            if (make->staticlib) strarray_add( &make->install[INSTALL_DEV], make->staticlib );
-            else strarray_add( &make->install[INSTALL_LIB], make->module );
-            for (arch = 1; arch < archs.count; arch++)
-            {
-                char *module;
-                if (!(module = get_expanded_arch_var( make, "MODULE", arch ))) continue;
-                strarray_add( &make->install[INSTALL_LIB], module );
-            }
+            char *module;
+            if (!(module = get_expanded_arch_var( make, "MODULE", arch ))) continue;
+            strarray_add( &make->install[INSTALL_LIB], module );
         }
     }
 


### PR DESCRIPTION
# Add winepipewire.drv, a native PipeWire mmdevapi driver

Ports the PipeWire audio driver from the wine-11.10 development tree onto the 11.0 base. Apps talk to PipeWire directly instead of going through pipewire-pulse, giving lower latency, proper per-client node names in graph tools, and sample-accurate sync between streams sharing a device and period.

## What's included

**Environment backports (10 commits)** - wine-11.0 predates the 11.10 audio ABI, so the unixlib-by-name loading infrastructure (`MemoryWineLoadUnixLibByName`), pure-unixlib makefile support, and the system-thread model for audio main/timer loops (`PsCreateSystemThread`) are backported first. Published WineHQ commits carry `cherry picked from` trailers; adapted ones are marked `partially picked` with a one-line deviation note. `PsCreateSystemThread` is reimplemented on 11.0 thread machinery rather than backporting the upstream thread-data refactor.

**Driver stack (6 commits)** - the driver itself, byte-identical to the upstream dev tree: WoW64 thunks for 32-bit clients, stream-group synchronization, client-derived node names, lowered minimum period, and safe process-detach teardown. PipeWire is preferred over PulseAudio when a daemon is available; `HKCU\Software\Wine\Drivers\Audio` still overrides.

Existing drivers (pulse, alsa, oss, coreaudio) are converted to the new thread model but keep their behavior.

## Validation

- mmdevapi test suite (mmdevenum, render, capture, dependency, spatialaudio): 0 failures on both i386 and x86_64 under pipewire. propstore has 6 pre-existing failures that reproduce identically under pulse.
- Pulse and ALSA regression runs clean on both arches after the thread-model backports.
- Exit-crash stress: 10/10 clean render runs.
- Latency/jitter bench: phase sd 0.007 ms across synced streams, zero drift, one shared timer thread per stream group.

Build with `--with-pipewire` (requires libpipewire-0.3 headers).
