### PR TITLE
ntdll: Support the system-thread audio model on 32-bit unix builds

### DIFF
--- a/dlls/ntdll/unix/signal_i386.c
+++ b/dlls/ntdll/unix/signal_i386.c
@@ -2192,7 +2192,8 @@ static void quit_handler( int signal, siginfo_t *siginfo, void *sigcontext )
     ucontext_t *ucontext = sigcontext;
 
     init_handler( sigcontext );
-    if (!is_inside_syscall( ESP_sig(ucontext) )) user_mode_abort_thread( 0, get_syscall_frame() );
+    if (!ntdll_get_thread_data()->system_thread && !is_inside_syscall( ESP_sig(ucontext) ))
+        user_mode_abort_thread( 0, get_syscall_frame() );
     abort_thread( 0 );
 }
 
@@ -2208,7 +2209,11 @@ static void usr1_handler( int signal, siginfo_t *siginfo, void *sigcontext )
 
     init_handler( sigcontext );
 
-    if (is_inside_syscall( ESP_sig(ucontext) ))
+    if (ntdll_get_thread_data()->system_thread)
+    {
+        server_select( NULL, 0, SELECT_INTERRUPTIBLE, 0, NULL, NULL );
+    }
+    else if (is_inside_syscall( ESP_sig(ucontext) ))
     {
         struct syscall_frame *frame = get_syscall_frame();
         ULONG64 saved_compaction = 0;
@@ -2401,6 +2406,11 @@ NTSTATUS signal_alloc_thread( TEB *teb )
         if (!thread_data->fs) return STATUS_TOO_MANY_THREADS;
     }
     else thread_data->fs = gdt_fs_sel;
+
+    /* libc TLS selector, same GDT slot in every thread.  signal_init_thread
+     * refreshes it for normal threads; system threads never run it, and
+     * init_handler would load gs=0 and break libc TLS in signal handlers. */
+    thread_data->gs = get_gs();
 
     teb->WOW32Reserved = __wine_syscall_dispatcher;
     thread_data->frame_size = frame_size;

--- a/dlls/winebus.sys/bus_sdl.c
+++ b/dlls/winebus.sys/bus_sdl.c
@@ -58,6 +58,23 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(hid);
 
+/* logic from SDL2's SDL_ShouldIgnoreGameController; also used by the udev
+ * backend, so it must exist even when SDL itself is not available */
+BOOL is_sdl_ignored_device(WORD vid, WORD pid)
+{
+    const char *whitelist = getenv("SDL_GAMECONTROLLER_IGNORE_DEVICES_EXCEPT");
+    const char *blacklist = getenv("SDL_GAMECONTROLLER_IGNORE_DEVICES");
+    char needle[16];
+
+    if (vid == 0x056a) return TRUE; /* all Wacom devices */
+    if (vid == 0x28de && pid == 0x11ff) return TRUE; /* Steam Input virtual controller, handled with evdev */
+
+    sprintf(needle, "0x%04x/0x%04x", vid, pid);
+    if (whitelist) return strcasestr(whitelist, needle) == NULL;
+    if (blacklist) return strcasestr(blacklist, needle) != NULL;
+    return FALSE;
+}
+
 #ifdef SONAME_LIBSDL2
 
 static pthread_mutex_t sdl_cs = PTHREAD_MUTEX_INITIALIZER;
@@ -928,21 +945,6 @@ static BOOL set_report_from_controller_event(struct sdl_device *impl, SDL_Event 
     return FALSE;
 }
 
-/* logic from SDL2's SDL_ShouldIgnoreGameController */
-BOOL is_sdl_ignored_device(WORD vid, WORD pid)
-{
-    const char *whitelist = getenv("SDL_GAMECONTROLLER_IGNORE_DEVICES_EXCEPT");
-    const char *blacklist = getenv("SDL_GAMECONTROLLER_IGNORE_DEVICES");
-    char needle[16];
-
-    if (vid == 0x056a) return TRUE; /* all Wacom devices */
-    if (vid == 0x28de && pid == 0x11ff) return TRUE; /* Steam Input virtual controller, handled with evdev */
-
-    sprintf(needle, "0x%04x/0x%04x", vid, pid);
-    if (whitelist) return strcasestr(whitelist, needle) == NULL;
-    if (blacklist) return strcasestr(blacklist, needle) != NULL;
-    return FALSE;
-}
 
 static void sdl_add_device(unsigned int index)
 {


### PR DESCRIPTION
## Summary

The PipeWire/mmdevapi port runs audio driver threads as unix system threads
(`PsCreateSystemThread`). The adaptation only patched the x86_64 signal
handlers, so old-style 32-bit builds (i386 unix side, non-WoW64) crashed
whenever a signal reached an audio thread: process exit, forced termination,
or debugger attach ended in SIGSEGV (unix exit 139).

This adds the missing i386 support and fixes an unrelated link failure that
broke SDL-less builds.

## Changes

- `ntdll: Export PsCreateSystemThread.` (amended)
  - `signal_i386.c`: mirror the x86_64 system-thread paths. `quit_handler`
    skips `user_mode_abort_thread` (system threads have no syscall frame);
    `usr1_handler` answers suspends with a bare
    `server_select(NULL, 0, SELECT_INTERRUPTIBLE, 0, NULL, NULL)`.
  - `signal_i386.c`: initialize `thread_data->gs` in `signal_alloc_thread`.
    System threads never run `signal_init_thread`, so `init_handler` loaded
    gs=0 and the first signal delivered to a system thread died in
    `pthread_getspecific` (recursive SIGSEGV). The selector is the same GDT
    TLS slot in every thread, so the creator's value is correct.
- `winebus.sys: Move is_sdl_ignored_device out of the SDL-only section.`
  - `bus_udev.c` calls it unconditionally, but it was defined inside
    `#ifdef SONAME_LIBSDL2`; any build without SDL failed to link. The
    function is plain env/string logic and needs no SDL.

## Validation

32-bit build (`build32`, `--with-wine64`, lib32-libpipewire 1.6.6), pure
`WINEARCH=win32` prefix, `Audio=pipewire`:

- mmdevapi conformance: mmdevenum/render/capture/dependency/spatialaudio
  0 failures, propstore 6 expected (fork extension).
- Bench harness: all 29 checks passed. Phase sd 0.006 ms, one shared timer
  (LWP 7), drift 0.0 us, tone RMS 0.1768 @ 440.2 Hz, 24-stream stress and
  300-cycle churn clean.
- Teardown: 10/10 clean tone exits, 3/3 clean `taskkill /f` mid-playback,
  `winedbg` attach mid-render suspends and resumes cleanly.
- WoW64 build unaffected (x86_64 unix side does not compile the changed
  i386 code).
