### PR TITLE
server: Backport system thread support (fixes GTA V Enhanced audio freeze)

### DIFF
--- a/dlls/ntdll/unix/signal_i386.c
+++ b/dlls/ntdll/unix/signal_i386.c
@@ -2192,7 +2192,8 @@ static void quit_handler( int signal, siginfo_t *siginfo, void *sigcontext )
     ucontext_t *ucontext = sigcontext;
 
     init_handler( sigcontext );
-    if (!is_inside_syscall( ESP_sig(ucontext) )) user_mode_abort_thread( 0, get_syscall_frame() );
+    if (!ntdll_get_thread_data()->system_thread && !is_inside_syscall( ESP_sig(ucontext) ))
+        user_mode_abort_thread( 0, get_syscall_frame() );
     abort_thread( 0 );
 }
 
@@ -2208,7 +2209,11 @@ static void usr1_handler( int signal, siginfo_t *siginfo, void *sigcontext )
 
     init_handler( sigcontext );
 
-    if (is_inside_syscall( ESP_sig(ucontext) ))
+    if (ntdll_get_thread_data()->system_thread)
+    {
+        server_select( NULL, 0, SELECT_INTERRUPTIBLE, 0, NULL, NULL );
+    }
+    else if (is_inside_syscall( ESP_sig(ucontext) ))
     {
         struct syscall_frame *frame = get_syscall_frame();
         ULONG64 saved_compaction = 0;
@@ -2401,6 +2406,11 @@ NTSTATUS signal_alloc_thread( TEB *teb )
         if (!thread_data->fs) return STATUS_TOO_MANY_THREADS;
     }
     else thread_data->fs = gdt_fs_sel;
+
+    /* libc TLS selector, same GDT slot in every thread.  signal_init_thread
+     * refreshes it for normal threads; system threads never run it, and
+     * init_handler would load gs=0 and break libc TLS in signal handlers. */
+    thread_data->gs = get_gs();
 
     teb->WOW32Reserved = __wine_syscall_dispatcher;
     thread_data->frame_size = frame_size;

--- a/dlls/ntdll/unix/thread.c
+++ b/dlls/ntdll/unix/thread.c
@@ -1526,6 +1526,7 @@ NTSTATUS WINAPI PsCreateSystemThread( HANDLE *handle, ACCESS_MASK access, OBJECT
         req->access     = access;
         req->flags      = THREAD_CREATE_FLAGS_BYPASS_PROCESS_FREEZE;
         req->request_fd = request_pipe[0];
+        req->is_system  = 1;
         wine_server_add_data( req, objattr, len );
         if (!(status = wine_server_call( req )))
         {

--- a/dlls/winebus.sys/bus_sdl.c
+++ b/dlls/winebus.sys/bus_sdl.c
@@ -58,6 +58,23 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(hid);
 
+/* logic from SDL2's SDL_ShouldIgnoreGameController; also used by the udev
+ * backend, so it must exist even when SDL itself is not available */
+BOOL is_sdl_ignored_device(WORD vid, WORD pid)
+{
+    const char *whitelist = getenv("SDL_GAMECONTROLLER_IGNORE_DEVICES_EXCEPT");
+    const char *blacklist = getenv("SDL_GAMECONTROLLER_IGNORE_DEVICES");
+    char needle[16];
+
+    if (vid == 0x056a) return TRUE; /* all Wacom devices */
+    if (vid == 0x28de && pid == 0x11ff) return TRUE; /* Steam Input virtual controller, handled with evdev */
+
+    sprintf(needle, "0x%04x/0x%04x", vid, pid);
+    if (whitelist) return strcasestr(whitelist, needle) == NULL;
+    if (blacklist) return strcasestr(blacklist, needle) != NULL;
+    return FALSE;
+}
+
 #ifdef SONAME_LIBSDL2
 
 static pthread_mutex_t sdl_cs = PTHREAD_MUTEX_INITIALIZER;
@@ -928,21 +945,6 @@ static BOOL set_report_from_controller_event(struct sdl_device *impl, SDL_Event 
     return FALSE;
 }
 
-/* logic from SDL2's SDL_ShouldIgnoreGameController */
-BOOL is_sdl_ignored_device(WORD vid, WORD pid)
-{
-    const char *whitelist = getenv("SDL_GAMECONTROLLER_IGNORE_DEVICES_EXCEPT");
-    const char *blacklist = getenv("SDL_GAMECONTROLLER_IGNORE_DEVICES");
-    char needle[16];
-
-    if (vid == 0x056a) return TRUE; /* all Wacom devices */
-    if (vid == 0x28de && pid == 0x11ff) return TRUE; /* Steam Input virtual controller, handled with evdev */
-
-    sprintf(needle, "0x%04x/0x%04x", vid, pid);
-    if (whitelist) return strcasestr(whitelist, needle) == NULL;
-    if (blacklist) return strcasestr(blacklist, needle) != NULL;
-    return FALSE;
-}
 
 static void sdl_add_device(unsigned int index)
 {

--- a/include/wine/server_protocol.h
+++ b/include/wine/server_protocol.h
@@ -1126,8 +1126,8 @@ struct new_thread_request
     unsigned int access;
     unsigned int flags;
     int          request_fd;
+    int          is_system;
     /* VARARG(objattr,object_attributes); */
-    char __pad_28[4];
 };
 struct new_thread_reply
 {
@@ -7209,6 +7209,6 @@ union generic_reply
     struct fsync_free_shm_idx_reply fsync_free_shm_idx_reply;
 };
 
-#define SERVER_PROTOCOL_VERSION 931
+#define SERVER_PROTOCOL_VERSION 932
 
 #endif /* __WINE_WINE_SERVER_PROTOCOL_H */

--- a/server/mapping.c
+++ b/server/mapping.c
@@ -1260,8 +1260,8 @@ void generate_startup_debug_events( struct process *process )
     /* generate creation events */
     LIST_FOR_EACH_ENTRY( thread, &process->thread_list, struct thread, proc_entry )
     {
-        if (thread != first_thread)
-            generate_debug_event( thread, DbgCreateThreadStateChange, NULL );
+        if (thread->is_system) continue;
+        if (thread != first_thread) generate_debug_event( thread, DbgCreateThreadStateChange, NULL );
     }
 
     /* generate dll events (in loading order) */

--- a/server/process.c
+++ b/server/process.c
@@ -1069,7 +1069,7 @@ void remove_process_thread( struct process *process, struct thread *thread )
         list_remove( &process->entry );
         process_killed( process );
     }
-    else generate_debug_event( thread, DbgExitThreadStateChange, thread );
+    else if (!thread->is_system) generate_debug_event( thread, DbgExitThreadStateChange, thread );
     release_object( thread );
 }
 

--- a/server/process.c
+++ b/server/process.c
@@ -556,9 +556,11 @@ void *get_ptid_entry( unsigned int id )
 /* return the main thread of the process */
 struct thread *get_process_first_thread( struct process *process )
 {
-    struct list *ptr = list_head( &process->thread_list );
-    if (!ptr) return NULL;
-    return LIST_ENTRY( ptr, struct thread, proc_entry );
+    struct thread *thread;
+
+    LIST_FOR_EACH_ENTRY( thread, &process->thread_list, struct thread, proc_entry )
+        if (!thread->is_system) return thread;
+    return NULL;
 }
 
 /* set the state of the process startup info */
@@ -679,6 +681,7 @@ struct process *create_process( int fd, struct process *parent, unsigned int fla
     process->unix_pid        = -1;
     process->exit_code       = STILL_ACTIVE;
     process->running_threads = 0;
+    process->user_threads    = 0;
     process->priority        = PROCESS_PRIOCLASS_NORMAL;
     process->base_priority   = 8;
     process->disable_boost   = 0;
@@ -1032,6 +1035,7 @@ static void process_killed( struct process *process )
 void add_process_thread( struct process *process, struct thread *thread )
 {
     list_add_tail( &process->thread_list, &thread->proc_entry );
+    if (!thread->is_system) process->user_threads++;
     if (!process->running_threads++)
     {
         list_add_tail( &process_list, &process->entry );
@@ -1055,6 +1059,7 @@ void remove_process_thread( struct process *process, struct thread *thread )
     assert( !list_empty( &process->thread_list ));
 
     list_remove( &thread->proc_entry );
+    if (!thread->is_system) process->user_threads--;
 
     if (!--process->running_threads)
     {
@@ -2078,9 +2083,9 @@ DECL_HANDLER(list_processes)
         reply->info_size = (reply->info_size + 7) & ~7;
         reply->info_size += sizeof(struct process_info) + process->imagelen;
         reply->info_size = (reply->info_size + 7) & ~7;
-        reply->info_size += process->running_threads * sizeof(struct thread_info);
+        reply->info_size += process->user_threads * sizeof(struct thread_info);
         reply->process_count++;
-        reply->total_thread_count += process->running_threads;
+        reply->total_thread_count += process->user_threads;
         reply->total_name_len += process->imagelen;
     }
 
@@ -2101,7 +2106,7 @@ DECL_HANDLER(list_processes)
         process_info = (struct process_info *)(buffer + pos);
         process_info->start_time = process->start_time;
         process_info->name_len = process->imagelen;
-        process_info->thread_count = process->running_threads;
+        process_info->thread_count = process->user_threads;
         process_info->priority = process->priority;
         process_info->pid = process->id;
         process_info->parent_pid = process->parent_id;
@@ -2116,6 +2121,7 @@ DECL_HANDLER(list_processes)
         {
             struct thread_info *thread_info = (struct thread_info *)(buffer + pos);
 
+            if (thread->is_system) continue;
             thread_info->start_time = thread->creation_time;
             thread_info->tid = thread->id;
             thread_info->base_priority = thread->base_priority;

--- a/server/process.h
+++ b/server/process.h
@@ -53,6 +53,7 @@ struct process
     int                  unix_pid;        /* Unix pid for final SIGKILL */
     int                  exit_code;       /* process exit code */
     int                  running_threads; /* number of threads running in this process */
+    int                  user_threads;    /* number of user threads running in this process */
     timeout_t            start_time;      /* absolute time at process start */
     timeout_t            end_time;        /* absolute time at process end */
     affinity_t           affinity;        /* process affinity mask */

--- a/server/protocol.def
+++ b/server/protocol.def
@@ -1127,6 +1127,7 @@ typedef volatile struct
     unsigned int access;       /* wanted access rights */
     unsigned int flags;        /* thread creation flags */
     int          request_fd;   /* fd for request pipe */
+    int          is_system;    /* system thread (kernel mode only) */
     VARARG(objattr,object_attributes); /* object attributes */
 @REPLY
     thread_id_t  tid;          /* thread id */

--- a/server/request.c
+++ b/server/request.c
@@ -591,7 +591,8 @@ static void master_socket_poll_event( struct fd *fd, int event )
         if (thread) clear_error();
         if ((process = create_process( client, thread ? thread->process : NULL, 0, NULL, NULL, NULL, 0, NULL )))
         {
-            create_thread( -1, process, NULL );
+            struct thread *main_thread = create_thread( -1, process, NULL );
+            if (main_thread) add_process_thread( process, main_thread );
             release_object( process );
         }
     }

--- a/server/request_handlers.h
+++ b/server/request_handlers.h
@@ -710,6 +710,7 @@ C_ASSERT( offsetof(struct new_thread_request, process) == 12 );
 C_ASSERT( offsetof(struct new_thread_request, access) == 16 );
 C_ASSERT( offsetof(struct new_thread_request, flags) == 20 );
 C_ASSERT( offsetof(struct new_thread_request, request_fd) == 24 );
+C_ASSERT( offsetof(struct new_thread_request, is_system) == 28 );
 C_ASSERT( sizeof(struct new_thread_request) == 32 );
 C_ASSERT( offsetof(struct new_thread_reply, tid) == 8 );
 C_ASSERT( offsetof(struct new_thread_reply, handle) == 12 );

--- a/server/request_trace.h
+++ b/server/request_trace.h
@@ -102,6 +102,7 @@ static void dump_new_thread_request( const struct new_thread_request *req )
     fprintf( stderr, ", access=%08x", req->access );
     fprintf( stderr, ", flags=%08x", req->flags );
     fprintf( stderr, ", request_fd=%d", req->request_fd );
+    fprintf( stderr, ", is_system=%d", req->is_system );
     dump_varargs_object_attributes( ", objattr=", cur_size );
 }
 

--- a/server/thread.c
+++ b/server/thread.c
@@ -579,7 +579,6 @@ struct thread *create_thread( int fd, struct process *process, const struct secu
     }
 
     set_fd_events( thread->request_fd, POLLIN );  /* start listening to events */
-    add_process_thread( thread->process, thread );
     return thread;
 
 error:
@@ -1729,6 +1728,7 @@ DECL_HANDLER(new_thread)
         thread->is_system = req->is_system;
         thread->dbg_hidden = !!(req->flags & THREAD_CREATE_FLAGS_HIDE_FROM_DEBUGGER);
         thread->bypass_proc_suspend = !!(req->flags & THREAD_CREATE_FLAGS_BYPASS_PROCESS_FREEZE);
+        add_process_thread( process, thread );
         reply->tid = get_thread_id( thread );
         if ((reply->handle = alloc_handle_no_access_check( current->process, thread,
                                                            req->access, objattr->attributes )))
@@ -1912,7 +1912,7 @@ DECL_HANDLER(get_thread_info)
             reply->flags |= GET_THREAD_INFO_FLAG_DBG_HIDDEN;
         if (thread->state == TERMINATED)
             reply->flags |= GET_THREAD_INFO_FLAG_TERMINATED;
-        if (thread->process->running_threads == 1)
+        if (thread->process->user_threads == 1)
             reply->flags |= GET_THREAD_INFO_FLAG_LAST;
         if (thread->disable_boost)
             reply->flags |= GET_THREAD_INFO_FLAG_DISABLE_BOOST;
@@ -2450,7 +2450,7 @@ DECL_HANDLER(get_next_thread)
     while (ptr)
     {
         thread = LIST_ENTRY( ptr, struct thread, entry );
-        if (thread->process == process &&
+        if (thread->process == process && !thread->is_system &&
             (reply->handle = alloc_handle( current->process, thread, req->access, req->attributes )))
         {
             release_object( process );

--- a/server/thread.c
+++ b/server/thread.c
@@ -1852,7 +1852,7 @@ DECL_HANDLER(init_thread)
     current->entry_point = req->entry;
 
     init_thread_context( current );
-    generate_debug_event( current, DbgCreateThreadStateChange, &req->entry );
+    if (!current->is_system) generate_debug_event( current, DbgCreateThreadStateChange, &req->entry );
     set_thread_base_priority( current, current->base_priority );
     set_thread_affinity( current, current->affinity );
 

--- a/server/thread.c
+++ b/server/thread.c
@@ -2160,6 +2160,13 @@ DECL_HANDLER(queue_apc)
             return;
         }
         thread = get_thread_from_handle( req->handle, THREAD_SET_CONTEXT );
+        if (thread && thread->is_system)
+        {
+            release_object( apc );
+            release_object( thread );
+            set_error( STATUS_ACCESS_DENIED );
+            return;
+        }
         if (thread && call && call->user.flags & SERVER_USER_APC_SPECIAL && is_wow64_process( thread->process ))
         {
             release_object( apc );
@@ -2292,6 +2299,8 @@ DECL_HANDLER(get_thread_context)
         if (!(thread = get_thread_from_handle( req->handle, THREAD_GET_CONTEXT ))) return;
         if (req->machine != native_machine && req->machine != thread->process->machine)
             set_error( STATUS_INVALID_PARAMETER );
+        else if (thread->is_system)
+            set_error( STATUS_ACCESS_DENIED );
         else if (thread->state != RUNNING)
             set_error( STATUS_UNSUCCESSFUL );
         else
@@ -2374,7 +2383,11 @@ DECL_HANDLER(set_thread_context)
     if (contexts[CTX_NATIVE].machine != native_machine ||
         (ctx_count == 2 && contexts[CTX_WOW].machine != thread->process->machine))
         set_error( STATUS_INVALID_PARAMETER );
-    else if (thread->state != TERMINATED)
+    else if (thread->is_system)
+        set_error( STATUS_ACCESS_DENIED );
+    else if (thread->state == TERMINATED)
+        set_error( STATUS_UNSUCCESSFUL );
+    else
     {
         unsigned int flags = system_flags & contexts[CTX_NATIVE].flags;
 
@@ -2409,7 +2422,6 @@ DECL_HANDLER(set_thread_context)
             }
         }
     }
-    else set_error( STATUS_UNSUCCESSFUL );
 
     release_object( thread );
 }

--- a/server/thread.c
+++ b/server/thread.c
@@ -407,6 +407,7 @@ static inline void init_thread_structure( struct thread *thread )
     thread->teb             = 0;
     thread->entry_point     = 0;
     thread->system_regs     = 0;
+    thread->is_system       = 0;
     thread->queue           = NULL;
     thread->wait            = NULL;
     thread->error           = 0;
@@ -1725,6 +1726,7 @@ DECL_HANDLER(new_thread)
     {
         thread->system_regs = current->system_regs;
         if (req->flags & THREAD_CREATE_FLAGS_CREATE_SUSPENDED) thread->suspend++;
+        thread->is_system = req->is_system;
         thread->dbg_hidden = !!(req->flags & THREAD_CREATE_FLAGS_HIDE_FROM_DEBUGGER);
         thread->bypass_proc_suspend = !!(req->flags & THREAD_CREATE_FLAGS_BYPASS_PROCESS_FREEZE);
         reply->tid = get_thread_id( thread );

--- a/server/thread.h
+++ b/server/thread.h
@@ -88,6 +88,7 @@ struct thread
     int                    base_priority; /* base priority level (relative to process base priority class) */
     int                    disable_boost; /* disable thread priority boost */
     int                    suspend;       /* suspend count */
+    int                    is_system;     /* system thread (kernel mode only) */
     int                    dbg_hidden;    /* hidden from debugger */
     int                    bypass_proc_suspend; /* will still run if the process is suspended */
     obj_handle_t           desktop;       /* desktop handle */


### PR DESCRIPTION
## Problem

GTA V Enhanced's anti-tamper periodically suspends every thread in the process and
reads its context. The mmdevapi audio driver threads (created via
`PsCreateSystemThread`) acknowledge the suspend but never report a context, so
`GetThreadContext` on them blocks forever - the sweep never reaches `ResumeThread`
and audio (then the game) freezes shortly after the main menu.

## Change

Backport the upstream 4-commit system-threads series: audio system threads are now
marked `is_system` on the server side, hidden from thread enumeration, deny
get/set context with `STATUS_ACCESS_DENIED`, and emit no debug events.

- `server: Add support for system threads.` (partially picked from 5155018f6f8)
- `server: Don't return system threads in enumerations.` (partially picked from 8a2788328c6)
- `server: Don't allow accessing the context of system threads.` (partially picked from 720ea07775e)
- `server: Don't send debug events for system threads.` (cherry picked from ca175f340c3)

Bumps `SERVER_PROTOCOL_VERSION` to 932 (generated request files regenerated via
`tools/make_requests`).

## Validation

- Suspend-sweep reproducer (enumerate + suspend + `GetThreadContext` all threads,
  10 s, audio playing): NO-HANG on x86_64 and i386; hangs reliably without the patch
- mmdevapi tests (pipewire driver): render + capture, 0 failures, both arches
- Bench harness: 35/35 checks (phase sd, drift, tone RMS unchanged)
- Proton-CachyOS build: patches 0032-0035 regenerated (no generated-file hunks per
  repo convention); installed tool reproducer-clean end to end
